### PR TITLE
fix: harden release workflow template (concurrency, timeout, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,25 @@ Create `.github/workflows/release.yml` in your repository:
 name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
     branches:
       - main
       - master
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   release:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       issues: write
@@ -38,6 +49,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Landfall: Automated semantic-release pipeline
+      # https://github.com/misty-step/landfall
       - name: Run Landfall
         uses: misty-step/landfall@v1
         with:

--- a/examples/release.yml
+++ b/examples/release.yml
@@ -1,7 +1,13 @@
 name: Release
 
 on:
-  push:
+  workflow_run:
+    # Replace "CI" if your primary pipeline uses a different workflow name.
+    workflows:
+      - CI
+    # Trigger only after the upstream CI workflow completes.
+    types:
+      - completed
     # Keep both names for repositories that still use master.
     branches:
       - main
@@ -9,9 +15,15 @@ on:
   # Optional manual trigger for one-off release runs.
   workflow_dispatch:
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # semantic-release and release body updates need write permissions.
     permissions:
       contents: write
@@ -27,6 +39,8 @@ jobs:
           # Landfall sets an authenticated remote URL during release.
           persist-credentials: false
 
+      # Landfall: Automated semantic-release pipeline
+      # https://github.com/misty-step/landfall
       - name: Run Landfall
         uses: misty-step/landfall@v1
         with:


### PR DESCRIPTION
## Summary
- harden the documented release workflow with CI-gated triggering
- add workflow-level concurrency controls
- add a 15-minute timeout for the release job
- add inline Landfall action comments in the recommended snippet and example workflow

## Testing
- python3 -m pytest -q