### PR TITLE
fix: remove npm plugin for non-Node project support

### DIFF
--- a/configs/.releaserc.json
+++ b/configs/.releaserc.json
@@ -13,18 +13,10 @@
       }
     ],
     [
-      "@semantic-release/npm",
-      {
-        "npmPublish": false
-      }
-    ],
-    [
       "@semantic-release/git",
       {
         "assets": [
-          "CHANGELOG.md",
-          "package.json",
-          "package-lock.json"
+          "CHANGELOG.md"
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }


### PR DESCRIPTION
Fixes misty-step/vox#178.

## Problem
The Landfall release action fails on non-Node projects (like Vox, a Swift app) with:
```
ENOPKG Missing package.json file
```

## Root Cause
The `.releaserc.json` config included:
1. `@semantic-release/npm` plugin which requires package.json
2. Git plugin configured to commit `package.json` and `package-lock.json`

## Solution
- Remove `@semantic-release/npm` plugin entirely
- Remove `package.json` and `package-lock.json` from git plugin assets

## Impact
Landfall now works for any project using conventional commits, regardless of language or package manager (Swift, Python, Go, Rust, etc.).

## Testing
This should fix the Vox Release workflow which has been failing 5+ consecutive runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration to streamline the continuous deployment pipeline. Adjusted npm package publishing behavior and refined version control asset tracking during releases. The process now focuses exclusively on changelog updates, excluding package manifest and dependency lock files from automated version control operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->