### PR TITLE
fix: provider-agnostic LLM inputs for release synthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Landfall
 
 Landfall is a focused release pipeline GitHub Action for repositories that use conventional commits.
-It runs `semantic-release` to publish a version and changelog, then optionally synthesizes user-facing notes with Moonshot/Kimi and prepends them to the GitHub Release body.
+It runs `semantic-release` to publish a version and changelog, then optionally synthesizes user-facing notes with any OpenAI-compatible LLM and prepends them to the GitHub Release body.
 
 ## What It Does
 
@@ -55,18 +55,30 @@ jobs:
         uses: misty-step/landfall@v1
         with:
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
-          moonshot-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+          llm-api-key: ${{ secrets.LLM_API_KEY }}
 ```
 
 ## Inputs
 
 | Input | Required | Default | Description |
 | --- | --- | --- | --- |
-| `github-token` | Yes | - | Personal access token with repo write access. Used by `semantic-release` and GitHub API update calls. |
-| `moonshot-api-key` | Yes | - | API key for Moonshot/Kimi synthesis. |
-| `moonshot-model` | No | `kimi-k2.5` | Moonshot model ID for note synthesis. |
+| `github-token` | Yes | — | Personal access token with repo write access. Used by `semantic-release` and GitHub API update calls. |
+| `llm-api-key` | Yes | — | API key for the LLM provider used for release-note synthesis. |
+| `llm-model` | No | `google/gemini-2.5-flash` | Model ID passed to the LLM provider. |
+| `llm-api-url` | No | `https://openrouter.ai/api/v1/chat/completions` | Chat-completions endpoint URL. Any OpenAI-compatible provider works (OpenRouter, OpenAI, Azure, etc.). |
 | `node-version` | No | `22` | Node.js version used to run `semantic-release`. |
 | `synthesis` | No | `true` | If `true`, generate and prepend user-facing notes. |
+
+### Deprecated Inputs
+
+The following inputs still work but will be removed in a future major version:
+
+| Input | Replacement |
+| --- | --- |
+| `moonshot-api-key` | `llm-api-key` |
+| `moonshot-model` | `llm-model` |
+
+If both the new and deprecated inputs are provided, the new inputs take precedence.
 
 ## Outputs
 
@@ -74,6 +86,39 @@ jobs:
 | --- | --- |
 | `released` | `true` if a new release/tag was created, otherwise `false`. |
 | `release-tag` | Tag created by `semantic-release` (empty if no release). |
+
+## Provider Examples
+
+### OpenRouter (default)
+
+```yaml
+- uses: misty-step/landfall@v1
+  with:
+    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+```
+
+### OpenAI
+
+```yaml
+- uses: misty-step/landfall@v1
+  with:
+    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    llm-api-key: ${{ secrets.OPENAI_API_KEY }}
+    llm-model: gpt-4o
+    llm-api-url: https://api.openai.com/v1/chat/completions
+```
+
+### Moonshot / Kimi (legacy)
+
+```yaml
+- uses: misty-step/landfall@v1
+  with:
+    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    llm-api-key: ${{ secrets.MOONSHOT_API_KEY }}
+    llm-model: kimi-k2.5
+    llm-api-url: https://api.moonshot.cn/v1/chat/completions
+```
 
 ## Default semantic-release Config
 

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,27 @@
 name: Landfall
-description: Focused release pipeline using semantic-release with optional Moonshot/Kimi synthesis.
+description: Focused release pipeline using semantic-release with optional LLM-powered synthesis.
 
 inputs:
   github-token:
     description: Personal access token with repository write access.
     required: true
-  moonshot-api-key:
-    description: API key for Moonshot/Kimi synthesis.
+  llm-api-key:
+    description: API key for the LLM provider used for release-note synthesis.
     required: true
+  llm-model:
+    description: Model ID passed to the LLM provider.
+    default: google/gemini-2.5-flash
+    required: false
+  llm-api-url:
+    description: Chat-completions endpoint URL. Any OpenAI-compatible provider works.
+    default: https://openrouter.ai/api/v1/chat/completions
+    required: false
+  # --- Deprecated aliases (backwards compatibility) ---
+  moonshot-api-key:
+    description: "[DEPRECATED — use llm-api-key] API key for Moonshot/Kimi synthesis."
+    required: false
   moonshot-model:
-    description: Moonshot model ID used for synthesis.
-    default: kimi-k2.5
+    description: "[DEPRECATED — use llm-model] Moonshot model ID used for synthesis."
     required: false
   node-version:
     description: Node.js version for semantic-release.
@@ -82,6 +93,26 @@ runs:
           echo "release_tag=" >> "${GITHUB_OUTPUT}"
         fi
 
+    - name: Resolve LLM inputs
+      id: llm
+      shell: bash
+      run: |
+        set -euo pipefail
+        # New inputs take precedence; fall back to deprecated moonshot-* aliases.
+        api_key="${{ inputs.llm-api-key }}"
+        [ -z "${api_key}" ] && api_key="${{ inputs.moonshot-api-key }}"
+
+        model="${{ inputs.llm-model }}"
+        if [ "${model}" = "google/gemini-2.5-flash" ] && [ -n "${{ inputs.moonshot-model }}" ]; then
+          model="${{ inputs.moonshot-model }}"
+        fi
+
+        api_url="${{ inputs.llm-api-url }}"
+
+        echo "api_key=${api_key}" >> "${GITHUB_OUTPUT}"
+        echo "model=${model}" >> "${GITHUB_OUTPUT}"
+        echo "api_url=${api_url}" >> "${GITHUB_OUTPUT}"
+
     - name: Synthesize user-facing notes
       id: synthesize
       if: inputs.synthesis == 'true' && steps.semantic_release.outputs.released == 'true'
@@ -91,8 +122,9 @@ runs:
         notes_file="${RUNNER_TEMP}/landfall-whats-new.md"
         product_name="${GITHUB_REPOSITORY#*/}"
         if ! python "${GITHUB_ACTION_PATH}/scripts/synthesize.py" \
-          --api-key "${{ inputs.moonshot-api-key }}" \
-          --model "${{ inputs.moonshot-model }}" \
+          --api-key "${{ steps.llm.outputs.api_key }}" \
+          --model "${{ steps.llm.outputs.model }}" \
+          --api-url "${{ steps.llm.outputs.api_url }}" \
           --product-name "${product_name}" \
           --version "${{ steps.semantic_release.outputs.release_tag }}" \
           --changelog-file "${GITHUB_WORKSPACE}/CHANGELOG.md" \

--- a/examples/release.yml
+++ b/examples/release.yml
@@ -46,10 +46,12 @@ jobs:
         with:
           # Personal access token with repository write access.
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
-          # Moonshot API key for synthesized "What's New" notes.
-          moonshot-api-key: ${{ secrets.MOONSHOT_API_KEY }}
-          # Optional model override.
-          moonshot-model: kimi-k2.5
+          # API key for the LLM provider (any OpenAI-compatible service).
+          llm-api-key: ${{ secrets.LLM_API_KEY }}
+          # Optional: model override (default: google/gemini-2.5-flash via OpenRouter).
+          # llm-model: google/gemini-2.5-flash
+          # Optional: custom chat-completions endpoint.
+          # llm-api-url: https://openrouter.ai/api/v1/chat/completions
           # Optional Node.js version for semantic-release.
           node-version: "22"
           # Set to "false" to skip synthesis and only publish technical notes.


### PR DESCRIPTION
## Summary

Replace Moonshot-specific inputs with generic LLM inputs that work with any OpenAI-compatible provider (OpenRouter, OpenAI, Azure, Moonshot, etc.).

## Changes

### `action.yml`
- **New inputs:** `llm-api-key`, `llm-model` (default: `google/gemini-2.5-flash`), `llm-api-url` (default: OpenRouter endpoint)
- **Deprecated aliases:** `moonshot-api-key` → `llm-api-key`, `moonshot-model` → `llm-model` (kept for backwards compat)
- **New step** `Resolve LLM inputs` merges new + deprecated inputs with new taking precedence
- **Synthesize step** now passes `--api-url` to `synthesize.py`

### `examples/release.yml`
- Updated to use the new `llm-api-key` input with commented examples for model/URL overrides

### `README.md`
- Documented all new inputs and deprecated aliases
- Added provider examples (OpenRouter, OpenAI, Moonshot/Kimi)
- Removed Moonshot-specific language from description

## Migration

Existing users using `moonshot-api-key` / `moonshot-model` — **no changes required**. The deprecated aliases continue to work. To switch to a different provider, replace them with:

```yaml
llm-api-key: ${{ secrets.LLM_API_KEY }}
llm-model: google/gemini-2.5-flash        # or any model your provider supports
# llm-api-url defaults to OpenRouter; override for other providers
```

## Notes

`scripts/synthesize.py` already accepts `--api-key`, `--model`, and `--api-url` — no script changes needed.

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support to any OpenAI-compatible LLM provider, not limited to Moonshot/Kimi.
  * Added ability to configure custom LLM API endpoint.

* **Deprecations**
  * Deprecated provider-specific input names in favor of generic LLM inputs; old inputs remain functional for backward compatibility with migration guidance provided.

* **Documentation**
  * Updated configuration examples to showcase multiple provider options including OpenAI and OpenRouter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->