### PR TITLE
chore: update branch references from main to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - main
       - master
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     branches:
-      - main
       - master
 
 jobs:

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -63,5 +63,5 @@ Steps:
 
 ## Git Workflow
 - Commit frequently with conventional commit messages
-- When done, push to origin main
+- When done, push to origin master
 - Write TASK_COMPLETE when finished

--- a/configs/.releaserc.json
+++ b/configs/.releaserc.json
@@ -1,6 +1,5 @@
 {
   "branches": [
-    "main",
     "master"
   ],
   "plugins": [


### PR DESCRIPTION
## Summary

Default branch was renamed from `main` to `master` on GitHub. This updates internal config to match:

- `.github/workflows/ci.yml` — remove `- main` from push trigger
- `.github/workflows/release.yml` — remove `- main` from push trigger
- `configs/.releaserc.json` — remove `"main"` from branches array
- `PROMPT.md` — change `origin main` to `origin master`

Consumer-facing examples (`README.md`, `CLAUDE.md`, `examples/release.yml`) intentionally keep both `main` and `master` since downstream repos may use either.

## Test plan

- [x] YAML and JSON validate
- [ ] CI triggers on push to master after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline and release automation configurations for consistency across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->