### PR TITLE
fix: harden self-release notes pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,31 @@ jobs:
           persist-credentials: false
 
       - name: Run Landfall
-        uses: misty-step/landfall@v1
+        id: landfall
+        uses: ./
         with:
           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          synthesis-strict: "true"
+
+      - name: Move v1 major tag
+        if: steps.landfall.outputs.released == 'true' && steps.landfall.outputs['release-tag'] != ''
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          RELEASE_TAG: ${{ steps.landfall.outputs['release-tag'] }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          release_sha="$(git rev-list -n 1 "${RELEASE_TAG}")"
+          if [ -z "${release_sha}" ]; then
+            echo "::error::Could not resolve release tag '${RELEASE_TAG}'."
+            exit 1
+          fi
+
+          git tag -f v1 "${release_sha}"
+          git push origin refs/tags/v1 --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,6 @@ The format is based on Keep a Changelog and uses Semantic Versioning.
 - Added structured logging and CLI input validation for Python scripts.
 - Improved synthesis prompt guidance for concise, user-friendly release notes.
 - Made synthesis and release-note update failures non-blocking in the composite action.
+- Switched Landfall self-release workflow to local `uses: ./` with OpenRouter input and strict synthesis checks.
+- Added automatic major tag sync (`v1` -> latest release tag) in the self-release workflow.
+- Removed deprecated `moonshot-*` action inputs in favor of `llm-*` provider-agnostic inputs.

--- a/README.md
+++ b/README.md
@@ -70,12 +70,11 @@ jobs:
 | `llm-model` | No | `anthropic/claude-sonnet-4` | Primary model ID for note synthesis. |
 | `llm-fallback-models` | No | `google/gemini-2.5-flash,openai/gpt-4o-mini` | Comma-separated fallback model IDs tried in order if primary fails. |
 | `llm-api-url` | No | `https://openrouter.ai/api/v1/chat/completions` | OpenAI-compatible chat completions endpoint URL. |
-| `moonshot-api-key` | No | - | Deprecated alias for `llm-api-key` (legacy workflows). |
-| `moonshot-model` | No | `kimi-k2.5` | Deprecated alias for `llm-model` (legacy workflows). |
 | `node-version` | No | `22` | Node.js version used to run `semantic-release`. |
 | `synthesis` | No | `true` | If `true`, generate and prepend user-facing notes. |
+| `synthesis-strict` | No | `false` | If `true`, fail the action when synthesis/update fails (instead of warning and continuing). |
 
-\* Provide `llm-api-key` (preferred) or `moonshot-api-key` (deprecated alias).
+\* `llm-api-key` is required when `synthesis: true`.
 
 ## Outputs
 
@@ -106,16 +105,32 @@ jobs:
     llm-api-url: https://api.openai.com/v1/chat/completions
 ```
 
-### Moonshot / Kimi (legacy)
+### Custom OpenAI-Compatible Provider
 
 ```yaml
 - uses: misty-step/landfall@v1
   with:
     github-token: ${{ secrets.GH_RELEASE_TOKEN }}
-    llm-api-key: ${{ secrets.MOONSHOT_API_KEY }}
-    llm-model: kimi-k2.5
-    llm-api-url: https://api.moonshot.cn/v1/chat/completions
+    llm-api-key: ${{ secrets.PROVIDER_API_KEY }}
+    llm-model: provider/model-id
+    llm-api-url: https://provider.example.com/v1/chat/completions
 ```
+
+## Dogfooding Landfall
+
+If Landfall releases itself, use local action code in `.github/workflows/release.yml`:
+
+```yaml
+- name: Run Landfall
+  id: landfall
+  uses: ./
+  with:
+    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+    synthesis-strict: "true"
+```
+
+Then move `v1` to the new `release-tag` output in the same workflow. This avoids stale major-tag drift.
 
 ## Default semantic-release Config
 

--- a/action.yml
+++ b/action.yml
@@ -20,12 +20,6 @@ inputs:
     description: Chat completions endpoint URL (OpenAI-compatible).
     default: "https://openrouter.ai/api/v1/chat/completions"
     required: false
-  moonshot-api-key:
-    description: "[Deprecated] Alias for llm-api-key for legacy workflows."
-    required: false
-  moonshot-model:
-    description: "[Deprecated] No longer used. Kept for workflow compatibility."
-    required: false
   node-version:
     description: Node.js version for semantic-release.
     default: "22"
@@ -33,6 +27,10 @@ inputs:
   synthesis:
     description: Whether to synthesize user-facing release notes.
     default: "true"
+    required: false
+  synthesis-strict:
+    description: Whether synthesis and release-body update failures should fail the action.
+    default: "false"
     required: false
 
 outputs:
@@ -104,7 +102,16 @@ runs:
         set -euo pipefail
         notes_file="${RUNNER_TEMP}/landfall-whats-new.md"
         product_name="${GITHUB_REPOSITORY#*/}"
-        api_key="${{ inputs.llm-api-key || inputs.moonshot-api-key }}"
+        strict="${{ inputs.synthesis-strict }}"
+        api_key="${{ inputs.llm-api-key }}"
+        if [ -z "${api_key}" ]; then
+          if [ "${strict}" = "true" ]; then
+            echo "::error::Landfall synthesis required but llm-api-key is empty."
+            exit 1
+          fi
+          echo "::warning::Landfall synthesis skipped; llm-api-key is empty."
+          exit 0
+        fi
         if ! python "${GITHUB_ACTION_PATH}/scripts/synthesize.py" \
           --api-key "${api_key}" \
           --model "${{ inputs.llm-model }}" \
@@ -115,11 +122,19 @@ runs:
           --changelog-file "${GITHUB_WORKSPACE}/CHANGELOG.md" \
           --prompt-template "${GITHUB_ACTION_PATH}/templates/synthesis-prompt.md" \
           > "${notes_file}"; then
+          if [ "${strict}" = "true" ]; then
+            echo "::error::Landfall synthesis failed and synthesis-strict is enabled."
+            exit 1
+          fi
           echo "::warning::Landfall synthesis failed; publishing release without a What's New section."
           exit 0
         fi
 
         if [ ! -s "${notes_file}" ]; then
+          if [ "${strict}" = "true" ]; then
+            echo "::error::Landfall synthesis returned empty notes and synthesis-strict is enabled."
+            exit 1
+          fi
           echo "::warning::Landfall synthesis returned empty notes; skipping release update."
           exit 0
         fi
@@ -131,10 +146,15 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        strict="${{ inputs.synthesis-strict }}"
         if ! python "${GITHUB_ACTION_PATH}/scripts/update-release.py" \
           --github-token "${{ inputs.github-token }}" \
           --repository "${GITHUB_REPOSITORY}" \
           --tag "${{ steps.semantic_release.outputs.release_tag }}" \
           --notes-file "${{ steps.synthesize.outputs.notes_file }}"; then
+          if [ "${strict}" = "true" ]; then
+            echo "::error::Landfall could not update the release body and synthesis-strict is enabled."
+            exit 1
+          fi
           echo "::warning::Landfall could not update the release body; release remains published."
         fi


### PR DESCRIPTION
## Summary
- switch Landfall self-release workflow to `uses: ./` so the repo releases with local action metadata
- add `synthesis-strict` mode and enable it in self-release to fail fast when notes generation/update fails
- remove deprecated `moonshot-*` inputs from `action.yml` and standardize on `llm-*` provider-agnostic inputs (OpenRouter-first default)
- add post-release step to move major tag `v1` to the new `release-tag` output and prevent tag drift
- update docs/changelog to reflect dogfooding and strict-mode behavior

## Root Cause
- `@v1` drifted and still pointed to `v1.0.0`, while current releases were `v1.1.x`
- self-release workflow was invoking `misty-step/landfall@v1`, so runs used stale inputs (`moonshot-api-key`) and stale synthesis path
- release logs (2026-02-08) show:
  - Moonshot path failures with 400 `invalid temperature: only 1 is allowed for this model`
  - later mismatch warning `Unexpected input(s) 'llm-api-key'` and `api-key must be non-empty`
- synthesis/update failures were non-blocking, so releases remained green without `## What's New`

## Validation
- `python -m ruff check scripts test`
- `python -m pytest -q test/`
- `python -m check_jsonschema --schemafile https://json.schemastore.org/github-action.json action.yml`

## Follow-up
- next release should verify release body includes `## What's New`
- optional backfill: patch release bodies for `v1.0.0`-`v1.1.3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `synthesis-strict` input to control strict failure handling for release synthesis operations
  * Automatic v1 major tag now syncs with the latest release

* **Breaking Changes**
  * Removed deprecated moonshot-api-key and moonshot-model inputs; use llm-* provider-agnostic inputs instead

* **Documentation**
  * Updated documentation with new input configurations and examples for custom OpenAI-compatible providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->