### PR TITLE
fix: remove unused @semantic-release/npm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ jobs:
           # llm-fallback-models: "google/gemini-2.5-flash,openai/gpt-4o-mini"
 ```
 
+Landfall is language-agnostic. Your repo does not need `package.json` or Node.js — the action handles its own runtime setup. Any project using conventional commits works.
+
 ## Inputs
 
 | Input | Required | Default | Description |
@@ -139,7 +141,6 @@ Landfall ships `configs/.releaserc.json` with:
 - `@semantic-release/commit-analyzer`
 - `@semantic-release/release-notes-generator`
 - `@semantic-release/changelog`
-- `@semantic-release/npm` (`npmPublish: false`)
 - `@semantic-release/git`
 - `@semantic-release/github`
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@semantic-release/commit-analyzer": "^11.1.0",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^10.3.5",
-    "@semantic-release/npm": "^12.0.1",
     "@semantic-release/release-notes-generator": "^12.1.0",
     "semantic-release": "^24.2.0"
   }


### PR DESCRIPTION
## Summary

- Removes `@semantic-release/npm` from `package.json` dependencies (plugin was already removed from `.releaserc.json` in c5e9dc0 but the dep survived)
- Updates README plugin list to match actual config
- Adds language-agnostic callout so consumers know no `package.json` or Node.js is needed

Closes #5

## Test plan

- [ ] Verify `npm install` in action context still succeeds (no missing peer deps)
- [ ] Confirm semantic-release runs without npm plugin (already proven in production since c5e9dc0)
- [ ] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)