### PR TITLE
chore: dedupe request retry + logging helpers

### DIFF
--- a/scripts/shared.py
+++ b/scripts/shared.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Shared script utilities.
+
+Keep scripts tiny: centralize structured logging + HTTP retry.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import requests
+
+
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def configure_logging(level_name: str) -> None:
+    level = getattr(logging, level_name.upper(), logging.INFO)
+    logging.basicConfig(level=level, format="%(message)s", stream=sys.stderr)
+
+
+def log_event(logger: logging.Logger, level: int, event: str, **fields: Any) -> None:
+    payload = {"event": event, **fields}
+    logger.log(level, json.dumps(payload, sort_keys=True, default=str))
+
+
+def request_with_retry(
+    logger: logging.Logger,
+    session: "requests.Session",
+    method: str,
+    url: str,
+    *,
+    timeout: int,
+    retries: int,
+    retry_backoff: float,
+    **kwargs: Any,
+) -> "requests.Response":
+    # Lazy import: some scripts only use logging helpers.
+    import requests
+
+    total_attempts = retries + 1
+    method_upper = method.upper()
+
+    for attempt in range(1, total_attempts + 1):
+        try:
+            response = session.request(method=method_upper, url=url, timeout=timeout, **kwargs)
+        except (requests.Timeout, requests.ConnectionError) as exc:
+            if attempt >= total_attempts:
+                raise
+
+            delay = retry_backoff * (2 ** (attempt - 1))
+            log_event(
+                logger,
+                logging.WARNING,
+                "http_retry_exception",
+                attempt=attempt,
+                max_attempts=total_attempts,
+                method=method_upper,
+                url=url,
+                wait_seconds=delay,
+                error_type=type(exc).__name__,
+            )
+            time.sleep(delay)
+            continue
+
+        if response.status_code in RETRYABLE_STATUS_CODES and attempt < total_attempts:
+            delay = retry_backoff * (2 ** (attempt - 1))
+            log_event(
+                logger,
+                logging.WARNING,
+                "http_retry_status",
+                attempt=attempt,
+                max_attempts=total_attempts,
+                method=method_upper,
+                url=url,
+                status_code=response.status_code,
+                wait_seconds=delay,
+            )
+            time.sleep(delay)
+            continue
+
+        response.raise_for_status()
+        return response
+
+    raise RuntimeError("failed to receive HTTP response")
+

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from types import ModuleType
 
@@ -12,6 +13,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 def load_script_module(module_name: str, relative_path: str) -> ModuleType:
     module_path = REPO_ROOT / relative_path
+    scripts_dir = str(module_path.parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load module from {module_path}")

--- a/test/test_synthesize.py
+++ b/test/test_synthesize.py
@@ -68,7 +68,7 @@ def test_extract_release_section_falls_back_to_latest_when_version_missing(synth
 
 
 def test_synthesize_notes_retries_retryable_status(synthesize, monkeypatch):
-    monkeypatch.setattr(synthesize.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(sys.modules["shared"].time, "sleep", lambda *_: None)
     session = FakeSession(
         [
             FakeResponse(status_code=500, payload={"error": "temporary"}, text="temporary"),
@@ -95,7 +95,7 @@ def test_synthesize_notes_retries_retryable_status(synthesize, monkeypatch):
 
 
 def test_synthesize_notes_timeout_raises_after_retries(synthesize, monkeypatch):
-    monkeypatch.setattr(synthesize.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(sys.modules["shared"].time, "sleep", lambda *_: None)
     session = FakeSession([requests.Timeout("first timeout"), requests.Timeout("second timeout")])
 
     with pytest.raises(requests.Timeout):

--- a/test/test_update_release.py
+++ b/test/test_update_release.py
@@ -64,7 +64,7 @@ def test_compose_release_body_replaces_existing_whats_new(update_release):
 
 
 def test_fetch_release_retries_on_retryable_status(update_release, monkeypatch):
-    monkeypatch.setattr(update_release.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(sys.modules["shared"].time, "sleep", lambda *_: None)
     session = FakeSession(
         [
             FakeResponse(status_code=502, payload={"message": "bad gateway"}, text="bad gateway"),

--- a/tests/test_write_artifacts.py
+++ b/tests/test_write_artifacts.py
@@ -16,6 +16,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 def load_script_module(module_name: str, relative_path: str) -> ModuleType:
     module_path = REPO_ROOT / relative_path
+    scripts_dir = str(module_path.parent)
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load module from {module_path}")


### PR DESCRIPTION
Closes #9

- Add scripts/shared.py: configure_logging(), log_event(), request_with_retry().
- Update scripts/synthesize.py + scripts/update-release.py to use shared helper.
- Tests: ensure script loader can import shared; patch shared time.sleep for retry tests.

Tests: python -m pytest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated shared logging and HTTP request utilities across internal scripts to reduce code duplication and improve maintainability.
  * Updated test infrastructure to support the reorganized module structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->