### PR TITLE
fix(ci): add dedicated workflow to sync v1 tag

### DIFF
--- a/.github/workflows/sync-v1-tag.yml
+++ b/.github/workflows/sync-v1-tag.yml
@@ -1,0 +1,51 @@
+name: Sync v1 Tag
+
+on:
+  push:
+    tags:
+      - 'v1.*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-v1-tag
+  cancel-in-progress: true
+
+jobs:
+  sync-v1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Move v1 to latest v1.x.x tag
+        run: |
+          set -euo pipefail
+          git fetch origin --tags --force
+
+          # Get the latest v1.x.x tag by version sort
+          latest_v1_tag=$(git tag -l 'v1.*' | grep -E '^v1\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+          
+          if [[ -z "$latest_v1_tag" ]]; then
+            echo "No v1.x.x tags found"
+            exit 0
+          fi
+
+          target_sha=$(git rev-list -n1 "$latest_v1_tag")
+          current_tag_sha=$(git rev-parse -q --verify refs/tags/v1 || true)
+          
+          if [[ "$current_tag_sha" == "$target_sha" ]]; then
+            echo "v1 already points to ${target_sha} (${latest_v1_tag})"
+            exit 0
+          fi
+
+          echo "Updating v1 tag from ${current_tag_sha:-none} to ${target_sha} (${latest_v1_tag})"
+          
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag -fa v1 "$target_sha" -m "Move v1 to ${latest_v1_tag} (${target_sha})"
+          git push origin refs/tags/v1 --force


### PR DESCRIPTION
Fixes #16

## Problem
Consuming repos referencing `misty-step/landfall@v1` were getting stale commits. GitHub Actions was downloading SHA `9fe104a` (v1.0.0) instead of the latest release.

## Solution
Add a dedicated sync-v1-tag.yml workflow that ensures the v1 floating tag always points to the latest v1.x.x release.

## How it works
- Triggers when any v1.* tag is pushed
- Finds the latest v1.x.x tag by version sort
- Updates the v1 floating tag to point to that commit
- Provides redundancy with the existing release.yml workflow

## Current State
The v1 tag is correctly pointing to v1.3.1 (3f114f1) currently. This workflow ensures it stays current for future releases.

## Testing
- [ ] Merge this PR
- [ ] Create a new v1.x.x tag to trigger the workflow
- [ ] Verify v1 tag updates automatically