### PR TITLE
fix(ci): correct test directory paths and add ruff config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
 
       - name: Lint Python
         shell: bash
-        run: python -m ruff check scripts test
+        run: python -m ruff check scripts/ tests/
 
       - name: Run tests
         shell: bash
-        run: python -m pytest -q test/
+        run: python -m pytest -q tests/
 
       - name: Validate action metadata
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,14 @@ requires-python = ">=3.12"
 [project.optional-dependencies]
 test = ["pytest", "requests"]
 
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+src = ["scripts", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["scripts"]


### PR DESCRIPTION
## Summary
- CI workflow referenced `test/` but tests live in `tests/` — both `ruff check` and `pytest` paths were wrong
- Added explicit `[tool.ruff]` config to `pyproject.toml` (target Python 3.12, 120-char lines, E/F/W rules)

Closes #11

## Test plan
- [ ] CI passes on this PR (ruff, pytest, action.yml schema validation)
- [ ] Verify no regressions on master merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated continuous integration workflow to improve testing consistency and code quality checks
  * Enhanced development environment configuration to enforce consistent coding standards across the project

<!-- end of auto-generated comment: release notes by coderabbit.ai -->