### PR TITLE
feat: add plaintext/html artifact outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Landfall is language-agnostic. Your repo does not need `package.json` or Node.js
 | `synthesis-strict` | No | `false` | Deprecated alias for `synthesis-required`. |
 | `synthesis-failure-issue` | No | `true` | If `true`, create a GitHub issue in the consuming repository when synthesis/update fails. |
 | `notes-output-file` | No | `""` | Write synthesized notes to this file path. Use `{version}` placeholder for the release tag (e.g., `docs/releases/{version}.md`). |
+| `notes-output-text-file` | No | `""` | Write synthesized notes as plaintext to this file path. Use `{version}` placeholder (e.g., `docs/releases/{version}.txt`). |
+| `notes-output-html-file` | No | `""` | Write synthesized notes as an HTML fragment to this file path. Use `{version}` placeholder (e.g., `docs/releases/{version}.html`). |
 | `notes-output-json` | No | `""` | Append a structured release entry to this JSON array file. Creates the file if it does not exist. |
 
 \* `llm-api-key` is required when `synthesis: true`.
@@ -137,6 +139,8 @@ For private repos where GitHub Releases aren't publicly visible, use artifact ou
     github-token: ${{ secrets.GH_RELEASE_TOKEN }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
     notes-output-file: docs/releases/{version}.md
+    notes-output-text-file: docs/releases/{version}.txt
+    notes-output-html-file: docs/releases/{version}.html
     notes-output-json: releases.json
 ```
 
@@ -147,7 +151,9 @@ This writes per-version markdown files and maintains a JSON feed for changelog p
   {
     "version": "1.2.0",
     "date": "2026-02-08",
-    "notes": "## New Features\n- ..."
+    "notes": "## New Features\n- ...",
+    "notes_plaintext": "New Features\n\n- ...",
+    "notes_html": "<h2>New Features</h2>\n<ul>\n<li>...</li>\n</ul>"
   }
 ]
 ```

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,14 @@ inputs:
     description: Write synthesized notes to this file path. Use {version} placeholder for the release tag (e.g., 'docs/releases/{version}.md').
     default: ""
     required: false
+  notes-output-text-file:
+    description: Write synthesized notes as plaintext to this file path. Use {version} placeholder (e.g., 'docs/releases/{version}.txt').
+    default: ""
+    required: false
+  notes-output-html-file:
+    description: Write synthesized notes as an HTML fragment to this file path. Use {version} placeholder (e.g., 'docs/releases/{version}.html').
+    default: ""
+    required: false
   notes-output-json:
     description: Append a structured release entry to this JSON array file. Creates the file if it does not exist.
     default: ""
@@ -278,6 +286,8 @@ runs:
             --notes-file "${{ steps.synthesize.outputs.notes_file }}" \
             --version "${{ steps.semantic_release.outputs.release_tag }}" \
             --output-file "${{ inputs.notes-output-file }}" \
+            --output-text-file "${{ inputs.notes-output-text-file }}" \
+            --output-html-file "${{ inputs.notes-output-html-file }}" \
             --output-json "${{ inputs.notes-output-json }}")" || true
           if [ -n "${notes_output}" ]; then
             notes="${notes_output}"

--- a/scripts/write-artifacts.py
+++ b/scripts/write-artifacts.py
@@ -5,14 +5,19 @@ from __future__ import annotations
 
 import argparse
 import datetime
+import html
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 
 LOGGER = logging.getLogger("landfall.write_artifacts")
+MARKDOWN_STRONG_RE = re.compile(r"\*\*(.+?)\*\*")
+MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 
 
 def configure_logging(level_name: str) -> None:
@@ -35,6 +40,16 @@ def parse_args() -> argparse.Namespace:
         "--output-file",
         default="",
         help="Output markdown path. Supports {version} placeholder.",
+    )
+    parser.add_argument(
+        "--output-text-file",
+        default="",
+        help="Output plaintext path (email/blog ready). Supports {version} placeholder.",
+    )
+    parser.add_argument(
+        "--output-html-file",
+        default="",
+        help="Output HTML fragment path. Supports {version} placeholder.",
     )
     parser.add_argument(
         "--output-json",
@@ -77,6 +92,143 @@ def write_notes_file(notes: str, output_path_template: str, version: str) -> Pat
     return destination
 
 
+def markdown_inline_to_plaintext(text: str) -> str:
+    # Keep this intentionally small. Landfall notes are constrained and should remain so.
+    stripped = text.strip()
+    if not stripped:
+        return ""
+
+    def replace_link(match: re.Match[str]) -> str:
+        label = match.group(1).strip()
+        url = match.group(2).strip()
+        if not url:
+            return label
+        return f"{label} ({url})"
+
+    stripped = MARKDOWN_LINK_RE.sub(replace_link, stripped)
+    stripped = re.sub(r"`([^`]+)`", r"\1", stripped)
+    stripped = MARKDOWN_STRONG_RE.sub(r"\1", stripped)
+    stripped = stripped.replace("*", "").replace("_", "")
+    stripped = re.sub(r"[ \t]+", " ", stripped)
+    return stripped.strip()
+
+
+def markdown_to_plaintext(markdown: str) -> str:
+    lines = markdown.splitlines()
+    rendered: list[str] = []
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            rendered.append("")
+            continue
+
+        if line.startswith("## "):
+            rendered.append(markdown_inline_to_plaintext(line[3:]))
+            rendered.append("")
+            continue
+
+        if line.startswith("- "):
+            rendered.append(f"- {markdown_inline_to_plaintext(line[2:])}")
+            continue
+
+        rendered.append(markdown_inline_to_plaintext(line))
+
+    text = "\n".join(rendered).strip()
+    return re.sub(r"\n{3,}", "\n\n", text) if text else ""
+
+
+def safe_link_href(url: str) -> str | None:
+    parsed = urlparse(url.strip())
+    if parsed.scheme in ("http", "https"):
+        return url.strip()
+    return None
+
+
+def markdown_inline_to_html(text: str) -> str:
+    # Minimal inline renderer: links + code + strong. Everything else escaped.
+    # Notes are trusted input (repo owner), but still escape to avoid surprises.
+    out: list[str] = []
+    i = 0
+    while i < len(text):
+        if text.startswith("**", i):
+            end = text.find("**", i + 2)
+            if end != -1:
+                strong = text[i + 2 : end]
+                out.append(f"<strong>{html.escape(strong, quote=True)}</strong>")
+                i = end + 2
+                continue
+
+        if text[i] == "`":
+            end = text.find("`", i + 1)
+            if end != -1:
+                code = text[i + 1 : end]
+                out.append(f"<code>{html.escape(code, quote=True)}</code>")
+                i = end + 1
+                continue
+
+        if text[i] == "[":
+            mid = text.find("](", i + 1)
+            if mid != -1:
+                end = text.find(")", mid + 2)
+                if end != -1:
+                    label = text[i + 1 : mid]
+                    url = text[mid + 2 : end]
+                    href = safe_link_href(url)
+                    if href:
+                        out.append(
+                            f'<a href="{html.escape(href, quote=True)}">{html.escape(label, quote=True)}</a>'
+                        )
+                    else:
+                        out.append(html.escape(label, quote=True))
+                        if url.strip():
+                            out.append(f" ({html.escape(url.strip(), quote=True)})")
+                    i = end + 1
+                    continue
+
+        out.append(html.escape(text[i], quote=True))
+        i += 1
+
+    return "".join(out)
+
+
+def markdown_to_html_fragment(markdown: str) -> str:
+    lines = markdown.splitlines()
+    rendered: list[str] = []
+    in_list = False
+
+    def close_list() -> None:
+        nonlocal in_list
+        if in_list:
+            rendered.append("</ul>")
+            in_list = False
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            close_list()
+            continue
+
+        if line.startswith("## "):
+            close_list()
+            rendered.append(f"<h2>{markdown_inline_to_html(line[3:])}</h2>")
+            continue
+
+        if line.startswith("- "):
+            if not in_list:
+                rendered.append("<ul>")
+                in_list = True
+            rendered.append(f"<li>{markdown_inline_to_html(line[2:])}</li>")
+            continue
+
+        close_list()
+        rendered.append(f"<p>{markdown_inline_to_html(line)}</p>")
+
+    close_list()
+    html_fragment = "\n".join(rendered).strip()
+    return html_fragment
+
+
 def normalize_json_version(version: str) -> str:
     if version.startswith("v"):
         return version[1:]
@@ -98,15 +250,23 @@ def append_json_entry(
     version: str,
     output_json_path: str,
     *,
+    notes_plaintext: str | None = None,
+    notes_html: str | None = None,
     today: datetime.date | None = None,
 ) -> Path:
     destination = Path(output_json_path)
     entries = load_json_array(destination)
+
+    derived_plaintext = notes_plaintext if notes_plaintext is not None else markdown_to_plaintext(notes)
+    derived_html = notes_html if notes_html is not None else markdown_to_html_fragment(notes)
+
     entries.append(
         {
             "version": normalize_json_version(version),
             "date": (today or datetime.date.today()).isoformat(),
             "notes": notes,
+            "notes_plaintext": derived_plaintext,
+            "notes_html": derived_html,
         }
     )
     ensure_parent_directory(destination)
@@ -129,6 +289,8 @@ def main() -> int:
 
     version = args.version.strip()
     output_file = args.output_file.strip()
+    output_text_file = args.output_text_file.strip()
+    output_html_file = args.output_html_file.strip()
     output_json = args.output_json.strip()
 
     try:
@@ -141,6 +303,9 @@ def main() -> int:
         log_event(logging.ERROR, "empty_notes_file", path=args.notes_file)
         return 1
 
+    notes_plaintext = markdown_to_plaintext(notes)
+    notes_html = markdown_to_html_fragment(notes)
+
     print(notes)
 
     if output_file:
@@ -150,9 +315,29 @@ def main() -> int:
             log_event(logging.ERROR, "notes_file_write_failed", path=output_file, error=str(exc))
             return 1
 
+    if output_text_file:
+        try:
+            write_notes_file(notes=notes_plaintext, output_path_template=output_text_file, version=version)
+        except OSError as exc:
+            log_event(logging.ERROR, "notes_file_write_failed", path=output_text_file, error=str(exc))
+            return 1
+
+    if output_html_file:
+        try:
+            write_notes_file(notes=notes_html, output_path_template=output_html_file, version=version)
+        except OSError as exc:
+            log_event(logging.ERROR, "notes_file_write_failed", path=output_html_file, error=str(exc))
+            return 1
+
     if output_json:
         try:
-            append_json_entry(notes=notes, version=version, output_json_path=output_json)
+            append_json_entry(
+                notes=notes,
+                version=version,
+                output_json_path=output_json,
+                notes_plaintext=notes_plaintext,
+                notes_html=notes_html,
+            )
         except json.JSONDecodeError as exc:
             log_event(logging.ERROR, "notes_json_parse_failed", path=output_json, error=str(exc))
             return 1
@@ -163,7 +348,7 @@ def main() -> int:
             log_event(logging.ERROR, "notes_json_write_failed", path=output_json, error=str(exc))
             return 1
 
-    if not output_file and not output_json:
+    if not output_file and not output_text_file and not output_html_file and not output_json:
         log_event(logging.INFO, "artifacts_noop")
 
     return 0


### PR DESCRIPTION
Closes #12

## What
- Add new action inputs:
  - `notes-output-text-file`
  - `notes-output-html-file`
- Extend JSON artifact entries (backward compatible):
  - keep `notes` (markdown)
  - add `notes_plaintext`
  - add `notes_html`

## How
- `scripts/write-artifacts.py` now derives plaintext + HTML (constrained markdown subset: `##` headings + `-` bullets).
- HTML output is escaped; only http/https links are turned into `<a href=...>`.

## Verification
- `python -m ruff check scripts/ tests/`
- `python -m pytest -q tests/`
- `python -m check_jsonschema --schemafile https://json.schemastore.org/github-action.json action.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `notes-output-text-file` and `notes-output-html-file` inputs to generate plaintext and HTML versions of release notes alongside existing Markdown and JSON outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->