### PR TITLE
feat: backfill CLI for retroactive release note synthesis

### DIFF
--- a/scripts/backfill.py
+++ b/scripts/backfill.py
@@ -160,7 +160,10 @@ def fetch_all_releases(
                 retries=retries,
                 retry_backoff=retry_backoff,
             )
-            payload = response.json()
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise RuntimeError("GitHub releases response was not valid JSON") from exc
             if not payload:
                 break
             if not isinstance(payload, list):
@@ -322,7 +325,7 @@ def main() -> int:
                     )
                     log_event(LOGGER, logging.INFO, "synthesis_succeeded", model=model, tag_name=tag_name)
                     break
-                except (requests.HTTPError, requests.RequestException, RuntimeError) as exc:
+                except (requests.HTTPError, requests.RequestException, RuntimeError, ValueError) as exc:
                     last_error = exc
                     error_fields: dict[str, Any] = {"error": str(exc)}
                     if isinstance(exc, requests.HTTPError) and exc.response is not None:


### PR DESCRIPTION
## Summary

- Adds `scripts/backfill.py` — standalone CLI to retroactively add "What's New" sections to existing GitHub releases
- Reuses `synthesize_notes()`, `compose_release_body()`, `update_release_body()` from existing scripts
- 8 new tests covering pagination, filtering, dry-run, error resilience, rate limiting, and summary output

## Usage

```bash
python scripts/backfill.py \
  --repo owner/repo \
  --github-token $GH_TOKEN \
  --llm-api-key $OPENROUTER_API_KEY \
  --prompt-template templates/synthesis-prompt.md \
  --dry-run
```

## Behavior

- Fetches all releases (paginated), filters out already-filled and empty-body releases
- Processes oldest-first for chronological consistency
- Supports model fallback chains, rate limiting between releases
- Continues on individual failures; prints summary at end
- `--dry-run` synthesizes but doesn't PATCH releases

## Test plan

- [x] 8 new tests in `tests/test_backfill.py` — all passing
- [x] Full suite (75 tests) passing
- [x] Ruff lint clean
- [ ] Manual dry-run against a test repo

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backfill tool that synthesizes and updates "What’s New" sections for existing GitHub releases; supports dry-run, rate limiting, retries, fallback models, configurable API and timing, and detailed summaries.

* **Tests**
  * Added comprehensive unit tests covering pagination, filtering, dry-run behavior, synthesis failures, rate limiting, argument validation, and summary reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->