### PR TITLE
feat: floating major version tags for Actions repos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
     description: Append a structured release entry to this JSON array file. Creates the file if it does not exist.
     default: ""
     required: false
+  floating-tags:
+    description: Update floating major version tags (e.g., v1) after release. Recommended for GitHub Actions repos.
+    default: "false"
+    required: false
 
 outputs:
   released:
@@ -123,6 +127,23 @@ runs:
           echo "released=false" >> "${GITHUB_OUTPUT}"
           echo "release_tag=" >> "${GITHUB_OUTPUT}"
         fi
+
+    - name: Update floating major tag
+      id: update_floating_tag
+      if: inputs.floating-tags == 'true' && steps.semantic_release.outputs.released == 'true'
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        release_tag="${{ steps.semantic_release.outputs.release_tag }}"
+        major_tag="$(python "${GITHUB_ACTION_PATH}/scripts/update-floating-tag.py" --release-tag "${release_tag}")"
+        sha="$(git rev-list -n 1 "${release_tag}")"
+
+        echo "Updating floating tag ${major_tag} → ${sha}"
+        git tag -f "${major_tag}" "${sha}"
+        git push origin "refs/tags/${major_tag}" --force
 
     - name: Synthesize user-facing notes
       id: synthesize

--- a/scripts/update-floating-tag.py
+++ b/scripts/update-floating-tag.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Parse a semver release tag and output the floating major version tag."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+
+def parse_major_tag(release_tag: str) -> str:
+    """Extract 'vN' from a semver tag like 'v1.2.3' or '1.2.3'."""
+    match = re.match(r"^v?(\d+)\.\d+\.\d+", release_tag)
+    if not match:
+        raise ValueError(f"invalid semver tag: {release_tag}")
+    return f"v{match.group(1)}"
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Output floating major tag for a release.")
+    parser.add_argument("--release-tag", required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        major_tag = parse_major_tag(args.release_tag)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+
+    print(major_tag)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,6 +102,11 @@ def post_session_factory():
 
 
 @pytest.fixture(scope="session")
+def update_floating_tag():
+    return load_script_module("landfall_update_floating_tag", "scripts/update-floating-tag.py")
+
+
+@pytest.fixture(scope="session")
 def update_release():
     return load_script_module("landfall_update_release", "scripts/update-release.py")
 

--- a/tests/test_update_floating_tag.py
+++ b/tests/test_update_floating_tag.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from conftest import load_script_module
+
+update_floating_tag = load_script_module(
+    "landfall_update_floating_tag", "scripts/update-floating-tag.py"
+)
+
+
+class TestParseMajorTag:
+    def test_standard_semver(self):
+        assert update_floating_tag.parse_major_tag("v1.2.3") == "v1"
+
+    def test_high_major(self):
+        assert update_floating_tag.parse_major_tag("v12.0.0") == "v12"
+
+    def test_v0(self):
+        assert update_floating_tag.parse_major_tag("v0.1.0") == "v0"
+
+    def test_without_v_prefix(self):
+        assert update_floating_tag.parse_major_tag("1.2.3") == "v1"
+
+    def test_prerelease_suffix_ignored(self):
+        assert update_floating_tag.parse_major_tag("v2.0.0-beta.1") == "v2"
+
+    def test_invalid_tag_raises(self):
+        with pytest.raises(ValueError, match="invalid semver tag"):
+            update_floating_tag.parse_major_tag("not-a-tag")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="invalid semver tag"):
+            update_floating_tag.parse_major_tag("")
+
+    def test_partial_version_raises(self):
+        with pytest.raises(ValueError, match="invalid semver tag"):
+            update_floating_tag.parse_major_tag("v1.2")
+
+
+class TestMain:
+    def test_prints_major_tag(self, capsys):
+        update_floating_tag.main(["--release-tag", "v3.1.4"])
+        assert capsys.readouterr().out.strip() == "v3"
+
+    def test_invalid_tag_exits(self):
+        with pytest.raises(SystemExit) as exc_info:
+            update_floating_tag.main(["--release-tag", "bad"])
+        assert exc_info.value.code == 1
+
+    def test_missing_arg_exits(self):
+        with pytest.raises(SystemExit):
+            update_floating_tag.main([])


### PR DESCRIPTION
## Summary
- Adds opt-in `floating-tags` input (default `false`) that force-moves `vN` tags after each release
- New `scripts/update-floating-tag.py` for semver tag parsing with full test coverage
- Post-release step runs only when `floating-tags: true` and a release was published

## Usage
```yaml
- uses: misty-step/landfall@v1
  with:
    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
    floating-tags: true  # ← force-moves v1 to latest release
```

Closes #28

## Test plan
- [x] 11 unit tests covering: standard semver, v0.x, no-prefix, prerelease suffix, invalid inputs, CLI behavior
- [x] Full suite passes (88/88)
- [x] Lint clean (ruff)
- [ ] Verify in a real release workflow (manual test on next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for automatically maintaining and updating floating major version tags (e.g., v1, v2) after each semantic release. Users can enable this feature through the new `floating-tags` configuration option, which is disabled by default. This feature is particularly useful for GitHub Actions repositories that want to keep major version tags current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->