### PR TITLE
feat: support consuming repo .releaserc override

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,13 @@ If Landfall releases itself, use local action code in `.github/workflows/release
 
 Then move `v1` to the new `release-tag` output in the same workflow. This avoids stale major-tag drift.
 
-## Default semantic-release Config
+## Custom semantic-release Config
 
-Landfall ships `configs/.releaserc.json` with:
+Landfall ships a default config at `configs/.releaserc.json`. If your repo has its own semantic-release config file (`.releaserc`, `.releaserc.json`, `.releaserc.yml`, `.releaserc.yaml`, `release.config.js`, `release.config.cjs`, or `release.config.mjs`), Landfall uses it instead of the bundled defaults.
+
+This lets you customize branches, plugins, commit-analyzer rules, or anything else semantic-release supports.
+
+If no config file is found, Landfall falls back to its bundled config with:
 
 - `@semantic-release/commit-analyzer`
 - `@semantic-release/release-notes-generator`

--- a/action.yml
+++ b/action.yml
@@ -110,12 +110,24 @@ runs:
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
+        # Detect consumer-provided semantic-release config
+        sr_extends_arg="--extends ${GITHUB_ACTION_PATH}/configs/.releaserc.json"
+        for config_file in .releaserc .releaserc.json .releaserc.yml .releaserc.yaml \
+                           release.config.js release.config.cjs release.config.mjs; do
+          if [ -f "${GITHUB_WORKSPACE}/${config_file}" ]; then
+            echo "::notice::Using repo semantic-release config: ${config_file}"
+            sr_extends_arg=""
+            break
+          fi
+        done
+
         before_tags="$(mktemp)"
         after_tags="$(mktemp)"
         git tag | sort > "${before_tags}"
 
+        # shellcheck disable=SC2086
         npx --yes --prefix "${GITHUB_ACTION_PATH}" semantic-release \
-          --extends "${GITHUB_ACTION_PATH}/configs/.releaserc.json"
+          ${sr_extends_arg}
 
         git tag | sort > "${after_tags}"
         new_tag="$(comm -13 "${before_tags}" "${after_tags}" | tail -n1 || true)"


### PR DESCRIPTION
## Summary

- Detect consumer-provided semantic-release config files (`.releaserc`, `.releaserc.json`, `.releaserc.yml`, `.releaserc.yaml`, `release.config.js`, `release.config.cjs`, `release.config.mjs`) in repo root
- When found, skip `--extends` flag so semantic-release uses the consumer's config natively
- When not found, fall back to Landfall's bundled config (current behavior, unchanged)
- Log which config source is used via `::notice::`

## Test plan

- [ ] Repo without `.releaserc` → uses Landfall defaults (existing behavior, all 90 tests pass)
- [ ] Repo with `.releaserc.json` → semantic-release uses repo config, notice logged
- [ ] Repo with `release.config.js` → same detection, same behavior

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The action now automatically detects and uses your repository's semantic-release configuration files, enabling customization of release behavior without requiring manual setup.

* **Documentation**
  * Updated README to clarify how the action discovers and applies semantic-release configurations, including support for multiple config file formats and fallback to default settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->