### PR TITLE
feat: rewrite synthesis system message and prompt template

### DIFF
--- a/scripts/synthesize.py
+++ b/scripts/synthesize.py
@@ -157,10 +157,27 @@ def extract_release_section(changelog_text: str, version: str | None) -> str:
     return changelog_text[start:end].strip()
 
 
+def estimate_bullet_target(version: str, technical: str) -> str:
+    """Suggest a bullet count range based on version bump and changelog size."""
+    normalized = normalize_version(version)
+    parts = normalized.split(".")
+    line_count = len([line for line in technical.splitlines() if line.strip().startswith("-")])
+
+    # Major version or many changes → more bullets
+    if len(parts) >= 1 and parts[0] != "0" and (normalized.endswith(".0.0") or line_count > 10):
+        return "5-10"
+    # Patch-only → fewer bullets
+    if len(parts) >= 3 and parts[1] == "0":
+        return "1-3"
+    return "3-7"
+
+
 def render_prompt(template_text: str, product_name: str, version: str, technical: str) -> str:
+    bullet_target = estimate_bullet_target(version, technical)
     return (
         template_text.replace("{{PRODUCT_NAME}}", product_name)
         .replace("{{VERSION}}", version)
+        .replace("{{BULLET_TARGET}}", bullet_target)
         .replace("{{TECHNICAL_CHANGELOG}}", technical)
     )
 
@@ -202,7 +219,17 @@ def synthesize_notes(
         "messages": [
             {
                 "role": "system",
-                "content": "You rewrite technical release notes into user-facing product notes.",
+                "content": (
+                    "You are a technical writer who transforms developer changelogs into "
+                    "release notes that users actually want to read. "
+                    "Explain what changed and why it matters. "
+                    "For new features, frame as 'You can now...' to highlight capability. "
+                    "For bug fixes, frame as 'Fixed...' to confirm resolution. "
+                    "For improvements, frame as 'The X now...' to show what got better. "
+                    "Never leak implementation details: no PR numbers, commit hashes, "
+                    "file paths, function names, or internal process references. "
+                    "Skip CI, tooling, refactors, and dependency bumps unless user-visible."
+                ),
             },
             {"role": "user", "content": prompt},
         ],

--- a/templates/synthesis-prompt.md
+++ b/templates/synthesis-prompt.md
@@ -1,26 +1,37 @@
 You are writing release notes for **{{PRODUCT_NAME}}** version **{{VERSION}}**.
 
-Rewrite the technical changelog into concise, user-facing notes.
+Transform the technical changelog below into user-facing release notes.
 
-Rules:
-- Use plain language and focus on user impact.
-- Keep each bullet to one short sentence.
-- Omit internal-only items (CI, tooling, refactors, dependency bumps) unless user-visible.
-- Never include PR numbers, commit hashes, issue IDs, or internal process details.
-- Keep the output tight: usually 3-7 bullets total.
+## Writing guidelines
 
-Output format:
-- Use only these section headings and this order (omit empty sections):
-  - `## New Features`
-  - `## Improvements`
-  - `## Bug Fixes`
-- Do not add any intro or outro text.
+- **Features:** Start with "You can now..." to frame new capabilities from the user's perspective.
+- **Bug fixes:** Start with "Fixed..." to confirm resolution clearly.
+- **Improvements:** Start with "The [thing] now..." to show what got better.
+- Each bullet should be one concise sentence explaining what changed and why it matters.
+- Omit internal-only items (CI, tooling, refactors, dependency bumps) unless they have user-visible impact.
+- Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.
+- Aim for {{BULLET_TARGET}} bullets total. More for feature-rich releases, fewer for patches.
 
-Few-shot examples:
+## Output format
+
+Use only these section headings in this order (omit sections with no items):
+
+```
+## New Features
+## Improvements
+## Bug Fixes
+```
+
+Do not add any intro, outro, summary, or sign-off text. Start directly with the first `##` heading.
+
+## Examples
+
+### Example 1: Feature release
 
 Technical changelog:
 ### Features
 - add one-click workspace import command
+- support custom theme colors in settings
 ### Bug Fixes
 - retry webhook processing when signatures expire
 ### Chores
@@ -28,10 +39,13 @@ Technical changelog:
 
 Expected release notes:
 ## New Features
-- Added one-click workspace import to reduce setup time.
+- You can now import workspace configuration in one click, reducing initial setup time.
+- You can now customize theme colors from the settings page.
 
 ## Bug Fixes
-- Webhook processing now retries after expired signatures to reduce failed deliveries.
+- Fixed webhook deliveries failing silently when signatures expired.
+
+### Example 2: Patch release
 
 Technical changelog:
 ### Bug Fixes
@@ -41,7 +55,21 @@ Technical changelog:
 
 Expected release notes:
 ## Bug Fixes
-- Fixed a dashboard crash that occurred when saving empty profile fields.
+- Fixed a dashboard crash that occurred when saving a profile with empty fields.
+
+### Example 3: Breaking change
+
+Technical changelog:
+### BREAKING CHANGES
+- remove deprecated /v1/auth endpoint
+### Features
+- add OAuth 2.0 PKCE authentication flow
+
+Expected release notes:
+## New Features
+- You can now authenticate using OAuth 2.0 with PKCE, replacing the deprecated v1 auth flow. If you were using the previous `/v1/auth` endpoint, switch to the new OAuth flow — see the migration guide for details.
+
+---
 
 Technical changelog source:
 

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -64,6 +64,35 @@ def test_render_prompt_replaces_template_tokens():
     assert rendered == "Name=Landfall Version=1.2.3\n\n### Fixes\n- stability"
 
 
+def test_render_prompt_replaces_bullet_target():
+    # Arrange
+    template = "Aim for {{BULLET_TARGET}} bullets.\n\n{{PRODUCT_NAME}} {{VERSION}}\n\n{{TECHNICAL_CHANGELOG}}"
+
+    # Act
+    rendered = synthesize.render_prompt(
+        template_text=template,
+        product_name="Test",
+        version="1.2.0",
+        technical="### Features\n- a\n- b\n- c",
+    )
+
+    # Assert
+    assert "3-7" in rendered
+    assert "{{BULLET_TARGET}}" not in rendered
+
+
+def test_estimate_bullet_target_major_release():
+    assert synthesize.estimate_bullet_target("2.0.0", "- a\n- b\n- c") == "5-10"
+
+
+def test_estimate_bullet_target_patch_release():
+    assert synthesize.estimate_bullet_target("1.0.1", "- a") == "1-3"
+
+
+def test_estimate_bullet_target_minor_release():
+    assert synthesize.estimate_bullet_target("1.2.0", "- a\n- b") == "3-7"
+
+
 def test_validate_args_accepts_valid_inputs():
     # Arrange
     args = argparse.Namespace(


### PR DESCRIPTION
## Summary

- Rich system persona with per-section voice: "You can now..." (features), "Fixed..." (bugs), "The X now..." (improvements)
- Expanded prompt template: 48 → 76 lines with 3 few-shot examples including breaking changes
- Dynamic `{{BULLET_TARGET}}` based on version bump type and changelog density
- New `estimate_bullet_target()` function: majors get 5-10, patches 1-3, minors 3-7
- 4 new tests for bullet target estimation and template rendering

## Before/After

**Before:** `"Added real-time collaboration cursors."`

**After:** `"You can now see other collaborators' cursors in real time while editing, making it easier to coordinate on shared documents."`

## Test plan

- [ ] 94 tests pass
- [ ] Major release (v2.0.0) → bullet target "5-10"
- [ ] Patch release (v1.0.1) → bullet target "1-3"
- [ ] Minor release (v1.2.0) → bullet target "3-7"
- [ ] Custom templates without `{{BULLET_TARGET}}` still work (no crash)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)