### PR TITLE
Add synthesis-only integration workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Landfall is language-agnostic. Your repo does not need `package.json` or Node.js
 Use `mode: synthesis-only` when another tool handles versioning and you only want Landfall for note synthesis:
 
 ```yaml
-- uses: misty-step/landfall@v2
+- uses: misty-step/landfall@v1
   with:
     mode: synthesis-only
     release-tag: ${{ steps.release.outputs.tag_name }}
@@ -144,6 +144,18 @@ Use `mode: synthesis-only` when another tool handles versioning and you only wan
 ```
 
 This skips Node.js setup and semantic-release entirely — only Python is installed for synthesis. Works with any release tool that creates GitHub Releases.
+
+## Integration with Other Tools
+
+When another release tool handles versioning and publication, run Landfall in `mode: synthesis-only` to add user-facing `## What's New` notes on top of the existing GitHub Release.
+
+Ready-to-copy workflows are available in `examples/`:
+
+- [`examples/release-please.yml`](examples/release-please.yml): `release-please` creates releases, then Landfall synthesizes notes for the new tag.
+- [`examples/changesets.yml`](examples/changesets.yml): `changesets/action` publishes releases, then Landfall synthesizes notes for the published tag.
+- [`examples/manual-tag.yml`](examples/manual-tag.yml): a manual tag push triggers synthesis and creates the GitHub Release first when needed.
+
+Each example is fully functional and includes inline comments for required permissions, secrets, and release-tag wiring.
 
 ## Portable Release Notes (Private Repos)
 

--- a/examples/changesets.yml
+++ b/examples/changesets.yml
@@ -1,0 +1,77 @@
+name: Release (changesets + Landfall)
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: changesets-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      # changesets/action updates release PRs and creates releases/tags.
+      contents: write
+      pull-requests: write
+      # Landfall can open/close synthesis failure issues.
+      issues: write
+
+    steps:
+      - name: Checkout repository history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Use a PAT if your repo requires permissions beyond GITHUB_TOKEN.
+          token: ${{ secrets.GH_RELEASE_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      # changesets/action either updates the release PR or publishes now.
+      - name: Create release PR or publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # Replace with your publish command.
+          publish: npm run release
+          # Keep release creation enabled so Landfall has a release to update.
+          createGithubReleases: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          # Required only if your publish command pushes to npm.
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Landfall needs an explicit tag. Grab the newest published release tag.
+      - name: Resolve published release tag
+        if: steps.changesets.outputs.published == 'true'
+        id: release_tag
+        env:
+          GH_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="$(gh release list --repo "${GITHUB_REPOSITORY}" --limit 1 --json tagName --jq '.[0].tagName')"
+          if [ -z "${tag}" ] || [ "${tag}" = "null" ]; then
+            echo "::error::No GitHub Release tag found after changesets publish."
+            exit 1
+          fi
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Synthesize user-facing notes with Landfall
+        if: steps.changesets.outputs.published == 'true'
+        uses: misty-step/landfall@v1
+        with:
+          mode: synthesis-only
+          release-tag: ${{ steps.release_tag.outputs.tag }}
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/examples/manual-tag.yml
+++ b/examples/manual-tag.yml
@@ -1,0 +1,53 @@
+name: Release Notes (manual tag + Landfall)
+
+on:
+  push:
+    tags:
+      # Adjust the pattern if your tags do not use a v-prefix.
+      - "v*"
+
+concurrency:
+  group: manual-tag-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  synthesize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout repository history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # If a tag is pushed manually without creating a release, create it so
+      # Landfall has a release body to update.
+      - name: Ensure GitHub Release exists for tag
+        env:
+          GH_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "GitHub Release already exists for ${RELEASE_TAG}"
+            exit 0
+          fi
+
+          gh release create "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${RELEASE_TAG}" \
+            --notes "Technical notes pending synthesis."
+
+      - name: Synthesize user-facing notes with Landfall
+        uses: misty-step/landfall@v1
+        with:
+          mode: synthesis-only
+          release-tag: ${{ github.ref_name }}
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/examples/release-please.yml
+++ b/examples/release-please.yml
@@ -1,0 +1,47 @@
+name: Release (release-please + Landfall)
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      # release-please creates/updates PRs and publishes releases.
+      contents: write
+      pull-requests: write
+      # Landfall can open/close synthesis failure issues.
+      issues: write
+
+    steps:
+      # release-please reads conventional commits and either:
+      # 1) updates/opens a release PR, or
+      # 2) publishes a GitHub Release when the release PR is merged.
+      - name: Run release-please
+        id: release
+        uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GH_RELEASE_TOKEN }}
+          # Pick the strategy that matches your repo.
+          release-type: simple
+
+      # Run Landfall only when release-please actually created a release.
+      # For monorepos, use path-scoped outputs like:
+      # steps.release.outputs['packages/my-lib--tag_name']
+      - name: Synthesize user-facing notes with Landfall
+        if: steps.release.outputs.release_created == 'true'
+        uses: misty-step/landfall@v1
+        with:
+          mode: synthesis-only
+          release-tag: ${{ steps.release.outputs.tag_name }}
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Summary
- add `examples/release-please.yml` with a release-please + Landfall synthesis-only flow
- add `examples/changesets.yml` with changesets publishing plus Landfall synthesis-only notes
- add `examples/manual-tag.yml` to synthesize notes on manual tag pushes
- add an "Integration with Other Tools" section in `README.md` linking these examples
- update the synthesis-only snippet to use `misty-step/landfall@v1`

## Validation
- `python3 -m pytest tests -k 'not check_version_sync'`
- `python3 -m pytest` (fails only in `tests/test_check_version_sync.py` on this machine because Python 3.9 lacks `tomllib`; project targets Python 3.12)

Closes #52


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Integration with Other Tools" section explaining synthesis-only mode for external release tools.
  * Provided three ready-to-copy workflow templates for different release automation platforms.
  * Updated version references in example workflows.

* **New Features**
  * Enhanced integration capabilities to prepend user-facing release notes to existing GitHub Releases when using external release pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->