### PR TITLE
feat: add audience-specific synthesis prompt variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Landfall is language-agnostic. Your repo does not need `package.json` or Node.js
 | `notes-output-text-file` | No | `""` | Write synthesized notes as plaintext to this file path. Use `{version}` placeholder (e.g., `docs/releases/{version}.txt`). |
 | `notes-output-html-file` | No | `""` | Write synthesized notes as an HTML fragment to this file path. Use `{version}` placeholder (e.g., `docs/releases/{version}.html`). |
 | `notes-output-json` | No | `""` | Append a structured release entry to this JSON array file. Creates the file if it does not exist. |
-| `prompt-template-path` | No | `""` | Path to a custom synthesis prompt template relative to repo root. Overrides convention-based detection. |
+| `prompt-template-path` | No | `""` | Path to a custom synthesis prompt template relative to repo root. Overrides `audience` and convention-based detection. |
+| `audience` | No | `general` | Built-in prompt variant used when no custom prompt template is found. One of: `general`, `developer`, `end-user`, `enterprise`. |
 
 \* `llm-api-key` is required when `synthesis: true`.
 
@@ -261,7 +262,16 @@ Landfall resolves the synthesis prompt template in this order:
 
 1. **Explicit input** — `prompt-template-path: my-templates/release.md`
 2. **Convention** — `.landfall/synthesis-prompt.md` in your repo root
-3. **Bundled default** — Landfall's built-in template
+3. **Bundled audience variant** — Landfall's built-in template selected by `audience` (default `general`)
+
+Built-in audience variants:
+
+| Audience | Template |
+| --- | --- |
+| `general` | [`templates/prompts/general.md`](templates/prompts/general.md) |
+| `developer` | [`templates/prompts/developer.md`](templates/prompts/developer.md) |
+| `end-user` | [`templates/prompts/end-user.md`](templates/prompts/end-user.md) |
+| `enterprise` | [`templates/prompts/enterprise.md`](templates/prompts/enterprise.md) |
 
 Custom templates must include these variables:
 
@@ -271,7 +281,7 @@ Custom templates must include these variables:
 | `{{VERSION}}` | Release version/tag |
 | `{{TECHNICAL_CHANGELOG}}` | Extracted changelog content |
 
-See [`templates/synthesis-prompt.md`](templates/synthesis-prompt.md) as a starting point for your own template.
+See [`templates/synthesis-prompt.md`](templates/synthesis-prompt.md) or [`templates/prompts/general.md`](templates/prompts/general.md) as a starting point for your own template.
 
 ## Example: Technical vs User-Facing
 

--- a/action.yml
+++ b/action.yml
@@ -65,8 +65,12 @@ inputs:
     default: ""
     required: false
   prompt-template-path:
-    description: Path to a custom synthesis prompt template (relative to repo root). Overrides convention-based detection (.landfall/synthesis-prompt.md).
+    description: Path to a custom synthesis prompt template (relative to repo root). Overrides audience and convention-based detection (.landfall/synthesis-prompt.md).
     default: ""
+    required: false
+  audience:
+    description: Built-in synthesis prompt variant used when no custom prompt template is found. One of general, developer, end-user, enterprise.
+    default: "general"
     required: false
   healthcheck:
     description: Validate LLM API key with a minimal probe request before synthesis. Catches stale or revoked keys early.
@@ -220,6 +224,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         PROMPT_TEMPLATE_PATH: ${{ inputs.prompt-template-path }}
+        AUDIENCE: ${{ inputs.audience }}
       run: |
         set -euo pipefail
 
@@ -267,8 +272,8 @@ runs:
           fi
         fi
 
-        # Resolve prompt template: explicit input > convention > bundled default
-        prompt_template="${GITHUB_ACTION_PATH}/templates/synthesis-prompt.md"
+        # Resolve prompt template: explicit input > convention > bundled audience variant
+        prompt_template=""
         if [ -n "${PROMPT_TEMPLATE_PATH}" ]; then
           custom_path="${GITHUB_WORKSPACE}/${PROMPT_TEMPLATE_PATH}"
           if [ ! -f "${custom_path}" ]; then
@@ -280,6 +285,8 @@ runs:
         elif [ -f "${GITHUB_WORKSPACE}/.landfall/synthesis-prompt.md" ]; then
           prompt_template="${GITHUB_WORKSPACE}/.landfall/synthesis-prompt.md"
           echo "::notice::Using repo prompt template: .landfall/synthesis-prompt.md"
+        else
+          echo "::notice::Using built-in prompt template audience: ${AUDIENCE}"
         fi
 
         synth_log="${RUNNER_TEMP}/landfall-synthesize.log"
@@ -289,6 +296,7 @@ runs:
           --api-url "${{ inputs.llm-api-url }}" \
           --fallback-models "${{ inputs.llm-fallback-models }}" \
           --product-name "${product_name}" \
+          --audience "${AUDIENCE}" \
           --version "${{ steps.resolve_release.outputs.release_tag }}" \
           ${changelog_arg} \
           --prompt-template "${prompt_template}" \

--- a/templates/prompts/developer.md
+++ b/templates/prompts/developer.md
@@ -1,0 +1,32 @@
+You are writing developer-focused release notes for **{{PRODUCT_NAME}}** version **{{VERSION}}**.
+
+Transform the technical changelog below into concise notes for engineers integrating or maintaining this product.
+
+## Writing guidelines
+
+- Prioritize integration impact: API behavior, configuration changes, migration implications, and reliability fixes.
+- For new capabilities, start bullets with "You can now...".
+- For fixes, start bullets with "Fixed...".
+- For improvements, start bullets with "The [thing] now...".
+- Include practical impact and required action when relevant (for example, update config, rotate key, rerun migration).
+- Omit purely internal items unless they directly affect users or integrators.
+- Never include PR numbers, commit hashes, issue IDs, file paths, or internal process details.
+- Aim for {{BULLET_TARGET}} bullets total.
+
+## Output format
+
+Use only these section headings in this order (omit sections with no items):
+
+```
+## New Features
+## Improvements
+## Bug Fixes
+```
+
+Do not add intro or summary text outside the sections.
+
+---
+
+Technical changelog source:
+
+{{TECHNICAL_CHANGELOG}}

--- a/templates/prompts/end-user.md
+++ b/templates/prompts/end-user.md
@@ -1,0 +1,33 @@
+You are writing end-user release notes for **{{PRODUCT_NAME}}** version **{{VERSION}}**.
+
+Transform the technical changelog below into simple, benefit-first updates for non-technical readers.
+
+## Writing guidelines
+
+- Use plain language and avoid jargon.
+- Focus on user outcomes: speed, reliability, clarity, ease of use, and reduced friction.
+- For new capabilities, start bullets with "You can now...".
+- For fixes, start bullets with "Fixed...".
+- For improvements, start bullets with "The [thing] now...".
+- Keep each bullet to one short sentence.
+- Omit internal-only changes unless they clearly improve user experience.
+- Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.
+- Aim for {{BULLET_TARGET}} bullets total.
+
+## Output format
+
+Use only these section headings in this order (omit sections with no items):
+
+```
+## New Features
+## Improvements
+## Bug Fixes
+```
+
+Do not add intro or summary text outside the sections.
+
+---
+
+Technical changelog source:
+
+{{TECHNICAL_CHANGELOG}}

--- a/templates/prompts/enterprise.md
+++ b/templates/prompts/enterprise.md
@@ -1,0 +1,34 @@
+You are writing enterprise release notes for **{{PRODUCT_NAME}}** version **{{VERSION}}**.
+
+Transform the technical changelog below into updates for security, compliance, and operations stakeholders.
+
+## Writing guidelines
+
+- Prioritize security and risk impact first, then reliability and platform updates.
+- Preserve CVE identifiers exactly when present (for example, `CVE-2024-1234`).
+- Explicitly call out compliance-relevant changes when mentioned (auditability, access control, encryption, retention).
+- For new capabilities, start bullets with "You can now...".
+- For fixes, start bullets with "Fixed...".
+- For improvements, start bullets with "The [thing] now...".
+- Include required follow-up actions when relevant (rotation, policy update, migration step).
+- Omit internal-only items unless they affect security posture, compliance, or operations.
+- Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.
+- Aim for {{BULLET_TARGET}} bullets total.
+
+## Output format
+
+Use only these section headings in this order (omit sections with no items):
+
+```
+## New Features
+## Improvements
+## Bug Fixes
+```
+
+Do not add intro or summary text outside the sections.
+
+---
+
+Technical changelog source:
+
+{{TECHNICAL_CHANGELOG}}

--- a/templates/prompts/general.md
+++ b/templates/prompts/general.md
@@ -1,0 +1,31 @@
+You are writing release notes for **{{PRODUCT_NAME}}** version **{{VERSION}}**.
+
+Transform the technical changelog below into user-facing release notes.
+
+## Writing guidelines
+
+- **Features:** Start with "You can now..." to frame new capabilities from the user's perspective.
+- **Bug fixes:** Start with "Fixed..." to confirm resolution clearly.
+- **Improvements:** Start with "The [thing] now..." to show what got better.
+- Each bullet should be one concise sentence explaining what changed and why it matters.
+- Omit internal-only items (CI, tooling, refactors, dependency bumps) unless they have user-visible impact.
+- Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.
+- Aim for {{BULLET_TARGET}} bullets total. More for feature-rich releases, fewer for patches.
+
+## Output format
+
+Use only these section headings in this order (omit sections with no items):
+
+```
+## New Features
+## Improvements
+## Bug Fixes
+```
+
+Do not add any intro, outro, summary, or sign-off text. Start directly with the first `##` heading.
+
+---
+
+Technical changelog source:
+
+{{TECHNICAL_CHANGELOG}}


### PR DESCRIPTION
## Summary
- add new `audience` action input with built-in variants: `general`, `developer`, `end-user`, `enterprise`
- preserve prompt precedence: `prompt-template-path` > `.landfall/synthesis-prompt.md` > built-in audience template
- update `scripts/synthesize.py` to resolve built-in prompt templates when no explicit template path is supplied
- add built-in prompt files under `templates/prompts/`
- add/expand tests for audience validation and template selection
- update README docs for new input and template resolution order

## Testing
- `pytest -q tests/test_synthesize.py`
- `pytest -q`

Closes #58


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `audience` configuration option to tailor release notes for different user types: general, developer, end-user, and enterprise variants.

* **Documentation**
  * Updated configuration documentation to describe the new audience selection mechanism and template customization guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->