### PR TITLE
docs: integration example workflows for release-please, changesets, and manual tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ Use `mode: synthesis-only` when another tool handles versioning and you only wan
 
 This skips Node.js setup and semantic-release entirely — only Python is installed for synthesis. Works with any release tool that creates GitHub Releases.
 
+### Integration with Other Tools
+
+Ready-to-use workflow examples for common release tools. Each uses `mode: synthesis-only` so Landfall only adds the synthesis layer.
+
+| Tool | Example | Trigger |
+| --- | --- | --- |
+| [release-please](https://github.com/googleapis/release-please-action) | [`examples/release-please.yml`](examples/release-please.yml) | Push to main (release-please creates the release) |
+| [Changesets](https://github.com/changesets/changesets) | [`examples/changesets.yml`](examples/changesets.yml) | Push to main (changesets publishes packages) |
+| Manual tags | [`examples/manual-tag.yml`](examples/manual-tag.yml) | Tag push matching `v*` |
+
+Copy the relevant example to `.github/workflows/` in your repository and update the secrets.
+
 ### Backfill Existing Releases
 
 Use `scripts/backfill.py` to repair already-published releases that are missing `## What's New`.

--- a/examples/changesets.yml
+++ b/examples/changesets.yml
@@ -1,0 +1,108 @@
+# Release pipeline using Changesets for versioning
+# and Landfall for user-facing note synthesis.
+#
+# How it works:
+#   1. Developers add changeset files via `npx changeset`
+#   2. changesets/action opens a "Version Packages" PR collecting pending changesets
+#   3. Merging that PR publishes packages and creates GitHub Releases
+#   4. Landfall synthesizes user-facing notes for the new release
+#
+# Requirements:
+#   - Repository secrets: GH_RELEASE_TOKEN, OPENROUTER_API_KEY
+#   - Changesets initialized in repo (`npx changeset init`)
+#   - publish script that creates GitHub Releases (e.g., `changeset tag`)
+#
+# Docs:
+#   - Changesets: https://github.com/changesets/changesets
+#   - changesets/action: https://github.com/changesets/action
+#   - Landfall: https://github.com/misty-step/landfall
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      published_packages: ${{ steps.changesets.outputs.publishedPackages }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - name: Create release PR or publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          # Your publish command. Should create GitHub Releases
+          # for Landfall to find and enhance.
+          publish: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  synthesize:
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Extract version from the first published package.
+      # Adjust the tag format (v{version}) to match your convention.
+      - name: Resolve release tag
+        id: tag
+        env:
+          PUBLISHED_PACKAGES: ${{ needs.release.outputs.published_packages }}
+        run: |
+          tag=$(echo "${PUBLISHED_PACKAGES}" \
+            | python3 -c "import sys,json; print('v' + json.load(sys.stdin)[0]['version'])")
+          echo "name=${tag}" >> "${GITHUB_OUTPUT}"
+
+      - uses: misty-step/landfall@v1
+        with:
+          mode: synthesis-only
+          release-tag: ${{ steps.tag.outputs.name }}
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          # Optional: customize synthesis behavior.
+          # audience: developer
+          # changelog-source: release-body
+
+# Monorepo variant: if changesets publishes multiple packages,
+# use a matrix strategy to synthesize notes for each release.
+#
+#   synthesize:
+#     needs: release
+#     if: needs.release.outputs.published == 'true'
+#     runs-on: ubuntu-latest
+#     strategy:
+#       matrix:
+#         package: ${{ fromJson(needs.release.outputs.published_packages) }}
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: misty-step/landfall@v1
+#         with:
+#           mode: synthesis-only
+#           release-tag: "${{ matrix.package.name }}@${{ matrix.package.version }}"
+#           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+#           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/examples/manual-tag.yml
+++ b/examples/manual-tag.yml
@@ -1,0 +1,65 @@
+# Synthesize release notes on manual tag push.
+#
+# How it works:
+#   1. You push a semver tag (v1.0.0, v2.3.1, etc.)
+#   2. A GitHub Release must already exist for that tag (create via gh CLI or UI)
+#   3. Landfall synthesizes user-facing notes and updates the release body
+#
+# This works with any workflow that creates releases and tags manually,
+# including `gh release create`, the GitHub UI, or custom scripts.
+#
+# Requirements:
+#   - Repository secrets: GH_RELEASE_TOKEN, OPENROUTER_API_KEY
+#   - A GitHub Release for the pushed tag (Landfall reads its body as input)
+#
+# Docs: https://github.com/misty-step/landfall
+
+name: Synthesize Release Notes
+
+on:
+  push:
+    tags:
+      - "v[0-9]*"
+
+jobs:
+  synthesize:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Landfall synthesis-only mode: skips semantic-release entirely,
+      # synthesizes user-facing notes for the tag that triggered this workflow.
+      - uses: misty-step/landfall@v1
+        with:
+          mode: synthesis-only
+          release-tag: ${{ github.ref_name }}
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          # Use the release body as source since there may be no CHANGELOG.md.
+          changelog-source: auto
+          # Optional: customize synthesis behavior.
+          # audience: developer
+          # llm-model: anthropic/claude-sonnet-4
+
+# Alternative: trigger on GitHub Release creation instead of tag push.
+# This guarantees a release exists before synthesis runs.
+#
+# on:
+#   release:
+#     types: [published]
+#
+# jobs:
+#   synthesize:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v4
+#       - uses: misty-step/landfall@v1
+#         with:
+#           mode: synthesis-only
+#           release-tag: ${{ github.event.release.tag_name }}
+#           github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+#           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/examples/release-please.yml
+++ b/examples/release-please.yml
@@ -1,0 +1,65 @@
+# Release pipeline using Google's release-please for versioning
+# and Landfall for user-facing note synthesis.
+#
+# How it works:
+#   1. release-please analyzes conventional commits and opens a "Release PR"
+#   2. When that PR merges, release-please creates the GitHub Release and tag
+#   3. Landfall synthesizes user-facing notes and updates the release body
+#
+# Requirements:
+#   - Repository secrets: GH_RELEASE_TOKEN, OPENROUTER_API_KEY
+#   - Conventional commits (https://www.conventionalcommits.org)
+#
+# Docs:
+#   - release-please: https://github.com/googleapis/release-please-action
+#   - Landfall: https://github.com/misty-step/landfall
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          # Change to match your project type:
+          # node, python, rust, go, simple, etc.
+          release-type: node
+
+  synthesize:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Landfall synthesis-only mode: skips semantic-release entirely,
+      # only runs LLM synthesis for the tag release-please just created.
+      - uses: misty-step/landfall@v1
+        with:
+          mode: synthesis-only
+          release-tag: ${{ needs.release-please.outputs.tag_name }}
+          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
+          # Optional: customize synthesis behavior.
+          # audience: developer
+          # llm-model: anthropic/claude-sonnet-4
+          # llm-fallback-models: "google/gemini-2.5-flash,openai/gpt-4o-mini"
+          # changelog-source: release-body


### PR DESCRIPTION
## Summary

Adds ready-to-copy workflow examples for repos that use release-please, changesets, or manual tag pushes instead of semantic-release. Each example uses `mode: synthesis-only` so Landfall only adds the LLM synthesis layer.

Closes #52

## Changes

- `examples/release-please.yml` — Two-job workflow: release-please creates the release, Landfall synthesizes notes
- `examples/changesets.yml` — Two-job workflow: changesets publishes, Landfall synthesizes (includes monorepo matrix variant in comments)
- `examples/manual-tag.yml` — Triggered on `v*` tag push, with alternative `release: published` trigger in comments
- `README.md` — Added "Integration with Other Tools" table linking to all three examples

## Acceptance Criteria

- [x] Three example workflow files in `examples/`
- [x] Each file is fully functional with inline comments
- [x] README has "Integration with Other Tools" section
- [x] No `${{ inputs.* }}` directly in `run:` blocks (security)
- [x] YAML validates cleanly
- [x] Existing tests still pass (149/149)

## Manual QA

1. Verify YAML syntax: `python3 -c "import yaml; [yaml.safe_load(open(f)) for f in ['examples/release-please.yml','examples/changesets.yml','examples/manual-tag.yml']]"`
2. Check README renders correctly on GitHub — the new table should appear between "Synthesis-Only Mode" and "Backfill Existing Releases"
3. Confirm each example references `misty-step/landfall@v1` with `mode: synthesis-only`

## Test Coverage

Documentation-only change. Existing test suite (149 tests) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added integration guide section to README documenting workflow examples for common release tools.

* **Chores**
  * Added three GitHub Actions workflow examples supporting Changesets, release-please, and manual semver tag-based release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->