### PR TITLE
feat(synthesis): release significance detection

### DIFF
--- a/scripts/synthesize.py
+++ b/scripts/synthesize.py
@@ -272,16 +272,20 @@ def classify_release(version: str, technical: str) -> tuple[str, str]:
     'major', 'feature', or 'patch'.
     """
     normalized = normalize_version(version)
+    # Strip prerelease/build metadata (e.g. "1.2.0-rc.1" → "1.2.0")
+    normalized = re.split(r"[-+]", normalized, maxsplit=1)[0]
     parts = normalized.split(".")
+    # Pad to 3 parts for partial versions (e.g. "2" → ["2","0","0"])
+    while len(parts) < 3:
+        parts.append("0")
 
     has_breaking = bool(BREAKING_CHANGE_RE.search(technical))
 
-    # Determine bump type from semver structure
     if has_breaking:
         significance = "major"
-    elif len(parts) >= 3 and parts[2] == "0" and parts[1] == "0" and parts[0] != "0":
+    elif parts[2] == "0" and parts[1] == "0" and parts[0] != "0":
         significance = "major"
-    elif len(parts) >= 3 and parts[2] != "0":
+    elif parts[2] != "0":
         significance = "patch"
     else:
         significance = "feature"

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -157,54 +157,49 @@ def test_render_prompt_replaces_bullet_target():
     assert "{{BULLET_TARGET}}" not in rendered
 
 
-def test_classify_release_major_version():
-    significance, bullet_target = synthesize.classify_release("2.0.0", "- a\n- b\n- c")
-    assert significance == "major"
-    assert bullet_target == "5-10"
-
-
-def test_classify_release_minor_version():
-    significance, bullet_target = synthesize.classify_release("1.2.0", "- a\n- b")
-    assert significance == "feature"
-    assert bullet_target == "3-7"
-
-
-def test_classify_release_patch_version():
-    significance, bullet_target = synthesize.classify_release("1.2.3", "- a")
-    assert significance == "patch"
-    assert bullet_target == "1-3"
-
-
-def test_classify_release_breaking_changes_elevates_to_major():
-    changelog = "### BREAKING CHANGES\n- removed /v1/auth endpoint\n### Features\n- added OAuth"
-    significance, bullet_target = synthesize.classify_release("1.3.0", changelog)
-    assert significance == "major"
-    assert bullet_target == "5-10"
-
-
-def test_classify_release_breaking_change_singular_heading():
-    changelog = "### BREAKING CHANGE\n- removed legacy API"
-    significance, bullet_target = synthesize.classify_release("1.1.0", changelog)
-    assert significance == "major"
-    assert bullet_target == "5-10"
-
-
-def test_classify_release_v_prefix_stripped():
-    significance, bullet_target = synthesize.classify_release("v3.0.0", "- rewrite")
-    assert significance == "major"
-    assert bullet_target == "5-10"
-
-
-def test_classify_release_prerelease_zero_major():
-    significance, bullet_target = synthesize.classify_release("0.5.0", "- new feature")
-    assert significance == "feature"
-    assert bullet_target == "3-7"
-
-
-def test_classify_release_patch_with_zero_minor():
-    significance, bullet_target = synthesize.classify_release("1.0.1", "- fix")
-    assert significance == "patch"
-    assert bullet_target == "1-3"
+@pytest.mark.parametrize(
+    ("version", "technical", "expected_significance", "expected_bullets"),
+    [
+        # Major version bumps
+        ("2.0.0", "- a\n- b\n- c", "major", "5-10"),
+        ("v3.0.0", "- rewrite", "major", "5-10"),
+        # Minor / feature releases
+        ("1.2.0", "- a\n- b", "feature", "3-7"),
+        ("0.5.0", "- new feature", "feature", "3-7"),
+        # Patch releases
+        ("1.2.3", "- a", "patch", "1-3"),
+        ("1.0.1", "- fix", "patch", "1-3"),
+        # Breaking changes elevate to major regardless of semver
+        ("1.3.0", "### BREAKING CHANGES\n- removed /v1/auth\n### Features\n- OAuth", "major", "5-10"),
+        ("1.1.0", "### BREAKING CHANGE\n- removed legacy API", "major", "5-10"),
+        # Prerelease suffixes stripped before classification
+        ("1.2.0-rc.1", "- new feature", "feature", "3-7"),
+        ("1.2.0+build.7", "- new feature", "feature", "3-7"),
+        ("2.0.0-beta.1", "- rewrite", "major", "5-10"),
+        # Partial version strings padded to 3 parts
+        ("2", "- rewrite", "major", "5-10"),
+        ("1.2", "- feature", "feature", "3-7"),
+    ],
+    ids=[
+        "major-2.0.0",
+        "major-v3.0.0",
+        "feature-1.2.0",
+        "feature-0.5.0",
+        "patch-1.2.3",
+        "patch-1.0.1",
+        "breaking-elevates-minor",
+        "breaking-singular-heading",
+        "prerelease-rc-stripped",
+        "build-metadata-stripped",
+        "prerelease-major",
+        "partial-major",
+        "partial-minor",
+    ],
+)
+def test_classify_release(version, technical, expected_significance, expected_bullets):
+    significance, bullet_target = synthesize.classify_release(version, technical)
+    assert significance == expected_significance
+    assert bullet_target == expected_bullets
 
 
 # Keep backward compat — estimate_bullet_target delegates to classify_release


### PR DESCRIPTION
## Summary

Adds `classify_release()` to detect release significance from semver structure and breaking change presence, replacing the crude `estimate_bullet_target()` heuristic. Patch bumps get 1-3 bullets, feature releases 3-7, major/breaking 5-10.

Closes #54

## Changes

- New `classify_release(version, technical)` → `(significance, bullet_target)` in `scripts/synthesize.py`
- Breaking change detection via regex scan for `### BREAKING CHANGE(S)` headings
- `estimate_bullet_target()` now delegates to `classify_release()` (backward compat)
- 8 new test cases covering major/minor/patch/breaking/v-prefix/pre-1.0 scenarios

## Acceptance Criteria

- [x] `classify_release("2.0.0", ...)` → `("major", "5-10")`
- [x] `classify_release("1.3.0", ...)` → `("feature", "3-7")`
- [x] `classify_release("1.2.3", ...)` → `("patch", "1-3")`
- [x] Breaking changes in changelog elevate any version to `"major"`
- [x] Existing `estimate_bullet_target()` API unchanged
- [x] `{{BULLET_TARGET}}` template token still works

## Manual QA

```bash
python -m pytest tests/test_synthesize.py -v -k classify_release
python -m pytest tests/ --no-header  # 157 passed
ruff check scripts/synthesize.py tests/test_synthesize.py
```

## Test Coverage

- `tests/test_synthesize.py`: 8 new tests for `classify_release()`, 3 existing `estimate_bullet_target` tests preserved
- All 157 tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added breaking-change detection and significance-based release classification (major/feature/patch) with guided bullet-count targets for clearer release notes.

* **Behavior**
  * Bullet-count estimation now derives from the new classification logic while remaining backward compatible.

* **Tests**
  * Added comprehensive tests covering version formats, prereleases, breaking-change wording, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->