### PR TITLE
Highlight breaking changes in synthesized notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,13 @@ Custom templates must include these variables:
 | `{{VERSION}}` | Release version/tag |
 | `{{TECHNICAL_CHANGELOG}}` | Extracted changelog content |
 
+Optional variables (supported, not required):
+
+| Variable | Value |
+| --- | --- |
+| `{{BULLET_TARGET}}` | Suggested bullet range (for example, `3-7`) |
+| `{{BREAKING_CHANGES_SECTION}}` | Breaking-change candidates extracted from the technical changelog (empty when none) |
+
 See [`templates/synthesis-prompt.md`](templates/synthesis-prompt.md) or [`templates/prompts/general.md`](templates/prompts/general.md) as a starting point for your own template.
 
 ## Example: Technical vs User-Facing

--- a/templates/prompts/developer.md
+++ b/templates/prompts/developer.md
@@ -2,8 +2,11 @@ You are writing developer-focused release notes for **{{PRODUCT_NAME}}** version
 
 Transform the technical changelog below into concise notes for engineers integrating or maintaining this product.
 
+{{BREAKING_CHANGES_SECTION}}
+
 ## Writing guidelines
 
+- Breaking changes: If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, why, migration steps. Do not repeat them in other sections.
 - Prioritize integration impact: API behavior, configuration changes, migration implications, and reliability fixes.
 - For new capabilities, start bullets with "You can now...".
 - For fixes, start bullets with "Fixed...".
@@ -18,6 +21,7 @@ Transform the technical changelog below into concise notes for engineers integra
 Use only these section headings in this order (omit sections with no items):
 
 ```
+## Breaking Changes
 ## New Features
 ## Improvements
 ## Bug Fixes

--- a/templates/prompts/end-user.md
+++ b/templates/prompts/end-user.md
@@ -2,14 +2,17 @@ You are writing end-user release notes for **{{PRODUCT_NAME}}** version **{{VERS
 
 Transform the technical changelog below into simple, benefit-first updates for non-technical readers.
 
+{{BREAKING_CHANGES_SECTION}}
+
 ## Writing guidelines
 
+- Breaking changes: If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, what to do next.
 - Use plain language and avoid jargon.
 - Focus on user outcomes: speed, reliability, clarity, ease of use, and reduced friction.
 - For new capabilities, start bullets with "You can now...".
 - For fixes, start bullets with "Fixed...".
 - For improvements, start bullets with "The [thing] now...".
-- Keep each bullet to one short sentence.
+- Keep each non-breaking bullet to one short sentence.
 - Omit internal-only changes unless they clearly improve user experience.
 - Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.
 - Aim for {{BULLET_TARGET}} bullets total.
@@ -19,6 +22,7 @@ Transform the technical changelog below into simple, benefit-first updates for n
 Use only these section headings in this order (omit sections with no items):
 
 ```
+## Breaking Changes
 ## New Features
 ## Improvements
 ## Bug Fixes

--- a/templates/prompts/enterprise.md
+++ b/templates/prompts/enterprise.md
@@ -2,8 +2,11 @@ You are writing enterprise release notes for **{{PRODUCT_NAME}}** version **{{VE
 
 Transform the technical changelog below into updates for security, compliance, and operations stakeholders.
 
+{{BREAKING_CHANGES_SECTION}}
+
 ## Writing guidelines
 
+- Breaking changes: If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, risk, required migration steps. Do not repeat them in other sections.
 - Prioritize security and risk impact first, then reliability and platform updates.
 - Preserve CVE identifiers exactly when present (for example, `CVE-2024-1234`).
 - Explicitly call out compliance-relevant changes when mentioned (auditability, access control, encryption, retention).
@@ -20,6 +23,7 @@ Transform the technical changelog below into updates for security, compliance, a
 Use only these section headings in this order (omit sections with no items):
 
 ```
+## Breaking Changes
 ## New Features
 ## Improvements
 ## Bug Fixes

--- a/templates/prompts/general.md
+++ b/templates/prompts/general.md
@@ -2,12 +2,15 @@ You are writing release notes for **{{PRODUCT_NAME}}** version **{{VERSION}}**.
 
 Transform the technical changelog below into user-facing release notes.
 
+{{BREAKING_CHANGES_SECTION}}
+
 ## Writing guidelines
 
+- **Breaking changes:** If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, why, migration steps. Do not repeat them in other sections.
 - **Features:** Start with "You can now..." to frame new capabilities from the user's perspective.
 - **Bug fixes:** Start with "Fixed..." to confirm resolution clearly.
 - **Improvements:** Start with "The [thing] now..." to show what got better.
-- Each bullet should be one concise sentence explaining what changed and why it matters.
+- Each non-breaking bullet should be one concise sentence explaining what changed and why it matters.
 - Omit internal-only items (CI, tooling, refactors, dependency bumps) unless they have user-visible impact.
 - Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.
 - Aim for {{BULLET_TARGET}} bullets total. More for feature-rich releases, fewer for patches.
@@ -17,6 +20,7 @@ Transform the technical changelog below into user-facing release notes.
 Use only these section headings in this order (omit sections with no items):
 
 ```
+## Breaking Changes
 ## New Features
 ## Improvements
 ## Bug Fixes

--- a/templates/synthesis-prompt.md
+++ b/templates/synthesis-prompt.md
@@ -2,12 +2,15 @@ You are writing release notes for **{{PRODUCT_NAME}}** version **{{VERSION}}**.
 
 Transform the technical changelog below into user-facing release notes.
 
+{{BREAKING_CHANGES_SECTION}}
+
 ## Writing guidelines
 
+- **Breaking changes:** If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, why, migration steps. Do not repeat them in other sections.
 - **Features:** Start with "You can now..." to frame new capabilities from the user's perspective.
 - **Bug fixes:** Start with "Fixed..." to confirm resolution clearly.
 - **Improvements:** Start with "The [thing] now..." to show what got better.
-- Each bullet should be one concise sentence explaining what changed and why it matters.
+- Each non-breaking bullet should be one concise sentence explaining what changed and why it matters.
 - Omit internal-only items (CI, tooling, refactors, dependency bumps) unless they have user-visible impact.
 - Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.
 - Aim for {{BULLET_TARGET}} bullets total. More for feature-rich releases, fewer for patches.
@@ -17,6 +20,7 @@ Transform the technical changelog below into user-facing release notes.
 Use only these section headings in this order (omit sections with no items):
 
 ```
+## Breaking Changes
 ## New Features
 ## Improvements
 ## Bug Fixes
@@ -66,8 +70,11 @@ Technical changelog:
 - add OAuth 2.0 PKCE authentication flow
 
 Expected release notes:
+## Breaking Changes
+- The deprecated `/v1/auth` endpoint was removed to simplify the authentication surface area. If you were using it, migrate to the new OAuth 2.0 PKCE flow before upgrading.
+
 ## New Features
-- You can now authenticate using OAuth 2.0 with PKCE, replacing the deprecated v1 auth flow. If you were using the previous `/v1/auth` endpoint, switch to the new OAuth flow — see the migration guide for details.
+- You can now authenticate using OAuth 2.0 with PKCE for a more secure sign-in flow.
 
 ---
 


### PR DESCRIPTION
Closes #55

What
- Extract breaking-change candidates from technical changelog (BREAKING CHANGES section, BREAKING CHANGE: footer, BREAKING: prefix, feat!/fix! lines).
- Inject candidates into prompt via optional `{{BREAKING_CHANGES_SECTION}}` token.
- Update built-in prompt templates to output `## Breaking Changes` first when present (2-3 sentences + migration steps), omit when absent.

Notes
- Custom templates keep working; token is optional.

Tests
- `python -m pytest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Release notes now include a dedicated "Breaking Changes" section displayed at the top, with improved detection across multiple changelog formats.

* **Documentation**
  * Updated release note templates with enhanced guidelines for formatting breaking changes, new features, improvements, and bug fixes.
  * Added documentation for new template customization variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->