### PR TITLE
Cerberus: stop timing out by default

### DIFF
--- a/.github/workflows/cerberus.yml
+++ b/.github/workflows/cerberus.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: misty-step/cerberus@v2.0.0
+      - uses: misty-step/cerberus@v2.9.0
         with:
           perspective: ${{ matrix.perspective }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -47,6 +47,6 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: misty-step/cerberus/verdict@v2.0.0
+      - uses: misty-step/cerberus/verdict@v2.9.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Problem
- Cerberus Council reviewers were always returning `SKIP` after timing out at 600s.
- Logs showed: `agent "<perspective>" not found. Falling back to default agent` → then a timeout.

Root Cause
- Landfall was pinned to `misty-step/cerberus@v2.0.0`, which predates the fix that stages Cerberus OpenCode config (`opencode.json` + `.opencode/agents/<perspective>.md`) into the consumer workspace. Without staging, OpenCode can’t discover the perspective agents.

Fix
- Bump `misty-step/cerberus` + `misty-step/cerberus/verdict` to `v2.9.0`.
- Keep a fast model + step cap to keep runtime predictable (`openrouter/google/gemini-2.5-flash`, `max-steps: 12`).

Result
- New Cerberus Council runs complete quickly and produce PASS/WARN/FAIL instead of SKIP.