### PR TITLE
ci: normalize merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Quality Checks
 
 on:
   pull_request:
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: python -m check_jsonschema --schemafile https://json.schemastore.org/github-action.json action.yml
 
-  CI:
+  merge-gate:
     runs-on: ubuntu-latest
     needs: [lockfile-check, python-checks]
     if: always()


### PR DESCRIPTION
## Why This Matters
- **Problem:** The repository's fan-in CI job currently surfaces as `CI / CI`, which hides the fact that it is the single merge gate reviewers should care about.
- **Value:** Renaming the workflow and gate job makes the blocking check legible (`Quality Checks / merge-gate`) without changing the underlying pass/fail behavior.
- **Why now:** This repo has several automated reviewers/checks on each PR; making the actual gate explicit reduces operator confusion when reading PR status and future ruleset wiring.
- **Issue:** No linked GitHub issue; this is a focused CI hygiene cleanup.

## Trade-offs / Risks
- **Value gained:** Clearer status-check naming for humans and future ruleset maintainers.
- **Cost / risk incurred:** The visible check name changes from `CI / CI` to `Quality Checks / merge-gate`.
- **Why this is still the right trade:** I verified the live `master` rules via `gh api repos/misty-step/landfall/rules/branches/master`; the matching org ruleset currently does **not** pin any named required status checks, so this rename does not create an enforcement gap in the repo's current configuration.
- **Reviewer watch-outs:** This PR is intentionally rename-only. The `if: always()` fan-in behavior and the failure/cancel handling are unchanged.

## What Changed
This PR renames the workflow from `CI` to `Quality Checks` and the aggregator job from `CI` to `merge-gate` so the single fan-in blocker reads like a blocker. No execution logic, dependencies, or failure semantics changed.

### Base Branch
```mermaid
graph TD
  PR[Pull request] --> L[lockfile-check]
  PR --> P[python-checks]
  L --> C[CI / CI]
  P --> C
  C --> M[Merge decision]
```

### This PR
```mermaid
graph TD
  PR[Pull request] --> L[lockfile-check]
  PR --> P[python-checks]
  L --> G[Quality Checks / merge-gate]
  P --> G
  G --> M[Merge decision]
```

### Architecture / State Change
```mermaid
sequenceDiagram
  participant PR as Pull Request
  participant Jobs as lockfile-check + python-checks
  participant Gate as Aggregator job
  participant Rules as master ruleset

  PR->>Jobs: run CI shards
  Jobs-->>Gate: success / failure / cancelled
  Note over Gate: same if: always() fan-in logic
  Gate-->>PR: status check label is renamed
  Rules-->>PR: current ruleset has no named required-status-check binding
```

Why this is better:
- The merge blocker now reads like a merge blocker.
- Reviewers can distinguish the real fan-in gate from informational bot checks faster.
- The PR avoids behavior churn; only the user-facing check names changed.

<details>
<summary>Intent Reference</summary>

## Intent Reference
- Commit intent: `ci: normalize required merge gate`
- Implemented intent: rename the legacy CI aggregator to an explicit merge gate while preserving the existing gating logic.
- No separate issue/spec was linked for this housekeeping change.

</details>

<details>
<summary>Changes</summary>

## Changes
- `.github/workflows/ci.yml`
  - renamed workflow `CI` → `Quality Checks`
  - renamed aggregator job `CI` → `merge-gate`
  - left all fan-in logic, job dependencies, and failure conditions unchanged

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] The visible workflow name is more descriptive than `CI`.
- [x] The fan-in gate job surfaces as `merge-gate`.
- [x] The gate still depends on `lockfile-check` and `python-checks`.
- [x] The gate still fails on upstream `failure` or `cancelled` results.
- [x] Validation evidence is attached in CI and in this stewardship pass.

</details>

<details>
<summary>Alternatives Considered</summary>

## Alternatives Considered
### Option A — Do nothing
- **Upside:** Zero status-check rename risk.
- **Downside:** Reviewers keep seeing an opaque `CI / CI` gate name.
- **Why rejected:** The current name obscures the job's purpose for little benefit.

### Option B — Rename the gate job but keep the workflow name
- **Upside:** Smaller visible rename.
- **Downside:** Still leaves a generic top-level workflow label and a less coherent status surface.
- **Why rejected:** If we are touching the naming, it's better to make the whole check line read clearly.

### Option C — Current approach
- **Upside:** Produces an explicit, legible status check while preserving the existing fan-in semantics.
- **Downside:** The visible check name changes.
- **Why chosen:** The repo's current `master` ruleset is not wired to named required checks, so the rename cost is acceptable and the clarity gain is immediate.

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
### Ruleset / metadata verification
- `gh api repos/misty-step/landfall/rules/branches/master`
  - verified current matching rules are PR / non-fast-forward / deletion protections
  - verified there is no named required-status-check binding on `master` today

### Local CI-equivalent rerun
```bash
uv venv --python 3.12 .venv
. .venv/bin/activate
uv pip install pytest requests ruff check-jsonschema
python -m ruff check scripts/ tests/
python -m pytest -q tests/
python -m check_jsonschema --schemafile https://json.schemastore.org/github-action.json action.yml
npm ci --no-fund --no-audit
```

### Observed results
- `ruff` — passed
- `pytest` — `315 passed`
- `check_jsonschema` — passed
- `npm ci --no-fund --no-audit` — passed
- PR GitHub Actions checks for `lockfile-check`, `python-checks`, and `merge-gate` — passed

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- **Renderer:** Terminal + diagram-led walkthrough
- **Artifact:** https://github.com/misty-step/landfall/pull/104#issuecomment-4032909682
- **Claim:** This PR renames the visible CI workflow/gate labels only; the underlying fan-in gate behavior is unchanged.
- **Before / After scope:** PR status surface, workflow naming, gate-job naming, and ruleset context for `master`
- **Persistent verification:** `python-checks`, `lockfile-check`, and `merge-gate` in GitHub Actions; local rerun of `ruff`, `pytest`, action metadata schema validation, and `npm ci`
- **Residual gap:** If the repo later adds named required-status-check rules, they should point at `Quality Checks / merge-gate`.

</details>

<details>
<summary>Before / After</summary>

## Before / After
### Before
- The fan-in job appeared as `CI / CI`, which was technically correct but not very descriptive.
- Reviewers had to infer that this was the actual merge gate rather than just another generic CI label.

### After
- The same fan-in job appears as `Quality Checks / merge-gate`.
- The blocking check now explains itself at a glance.
- No screenshots are needed because the change is internal to GitHub Actions/status-check naming.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- Existing automated coverage exercised during stewardship:
  - `tests/` via `python -m pytest -q tests/`
  - Python linting via `python -m ruff check scripts/ tests/`
  - Action metadata schema validation via `python -m check_jsonschema ... action.yml`
  - Node dependency integrity via `npm ci --no-fund --no-audit`
- No new tests were added because the PR changes labels only and leaves execution logic untouched.

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- **Confidence level:** High
- **Strongest evidence:** The diff is rename-only, all existing PR checks are green, and the stewardship rerun of the local CI-equivalent commands passed.
- **Remaining uncertainty:** None about workflow behavior; only future repo-configuration work could change whether a named status check should be pinned.
- **What could still go wrong after merge:** If maintainers later add a named required-status-check rule and point it at the wrong check, branch enforcement could be misconfigured — but that would be a separate repository-settings change, not a behavior regression from this PR.

</details>