### PR TITLE
Fix TruffleHog duplicate fail flag

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -24,4 +24,4 @@ jobs:
           path: ./
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
-          extra_args: --results=verified,unknown --fail
+          extra_args: --results=verified,unknown


### PR DESCRIPTION
## Summary
- remove duplicate `--fail` from TruffleHog `extra_args`; the action already supplies `--fail`

## Verification
- actionlint
- python scripts/check-action-contract.py
- python -m pytest -q tests/ -> 343 passed
- python -m ruff check scripts/ tests/
- rg -n "extra_args:.*--fail|--fail" .github/workflows/trufflehog.yml returned no matches

## Context
PR #105 squash-merged successfully, but the non-required TruffleHog check failed with `flag fail cannot be repeated`. This fixes that workflow configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TruffleHog security scanning configuration so the workflow will continue execution even if security findings are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->