### PR TITLE
Align master workflows with branch protection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,7 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
 
 jobs:
   release:

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches:
-      - main
       - master
 
 permissions:
@@ -22,6 +21,6 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           extra_args: --results=verified,unknown

--- a/README.md
+++ b/README.md
@@ -299,6 +299,12 @@ This repository keeps `package.json` and `pyproject.toml` versions aligned to re
 - The release commit includes `CHANGELOG.md`, `package.json`, and `pyproject.toml`.
 - CI runs `python scripts/check-version-sync.py` to fail fast when metadata drifts from the latest semver tag.
 
+Landfall's own release workflow is manual because `master` is protected by the
+required `merge-gate` check. Automatic self-release would need a PR-based
+release-commit path before it can safely publish generated changelog and version
+metadata back to `master`; manual dispatch should be used only after that path
+or a bypass-capable release token exists.
+
 ### Action Contract Validation (Landfall Repo)
 
 The public action contract is checked from `action.yml`:

--- a/backlog.d/007-build-pr-based-self-release.md
+++ b/backlog.d/007-build-pr-based-self-release.md
@@ -1,0 +1,26 @@
+# Build PR-based self-release under branch protection
+
+Priority: P2 · Status: pending · Estimate: L
+
+## Goal
+Let Landfall dogfood automatic self-release without requiring direct pushes to
+protected `master`.
+
+## Oracle
+- [ ] A release run can generate `CHANGELOG.md`, `package.json`, and
+      `pyproject.toml` changes on a release branch.
+- [ ] The generated release branch opens or updates a pull request whose checks
+      include `merge-gate`.
+- [ ] The workflow publishes the GitHub Release only after the generated release
+      PR lands.
+- [ ] A replay command proves the protected-branch path without mutating
+      production releases.
+
+## Notes
+- Evidence: the `2026-06-11` `Release` run for commit
+  `12441ec32afb35156e1c00eb62a3c32514919b8d` failed when
+  `@semantic-release/git` tried to push `HEAD:master`; GitHub rejected it
+  because `master` requires the `merge-gate` status check.
+- Current mitigation: Landfall's own release workflow is manual so normal
+  `master` pushes do not run a release job that cannot pass under current branch
+  protection.

--- a/tests/test_release_workflow_dogfooding.py
+++ b/tests/test_release_workflow_dogfooding.py
@@ -17,6 +17,12 @@ def test_release_workflow_runs_local_landfall_action() -> None:
     assert "name: Run Landfall" in workflow
 
 
+def test_release_workflow_is_manual_for_protected_master() -> None:
+    workflow = _release_workflow()
+    assert "workflow_dispatch:" in workflow
+    assert "push:" not in workflow
+
+
 def test_release_workflow_uses_landfall_for_strictness_and_floating_tags() -> None:
     workflow = _release_workflow()
     assert 'synthesis-required: "true"' in workflow

--- a/tests/test_trufflehog_workflow.py
+++ b/tests/test_trufflehog_workflow.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TRUFFLEHOG_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "trufflehog.yml"
+
+
+def _trufflehog_workflow() -> str:
+    return TRUFFLEHOG_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def test_trufflehog_uses_event_range_on_master_push() -> None:
+    workflow = _trufflehog_workflow()
+    assert "- master" in workflow
+    assert "- main" not in workflow
+    assert "github.event.before" in workflow
+    assert "github.sha" in workflow
+
+
+def test_trufflehog_uses_pr_sha_range_on_pull_request() -> None:
+    workflow = _trufflehog_workflow()
+    assert "github.event.pull_request.base.sha" in workflow
+    assert "github.event.pull_request.head.sha" in workflow
+
+
+def test_trufflehog_does_not_compare_default_branch_to_head() -> None:
+    workflow = _trufflehog_workflow()
+    assert "github.event.repository.default_branch" not in workflow
+    assert "head: HEAD" not in workflow


### PR DESCRIPTION
## Summary
- make TruffleHog scan the actual PR or master-push commit range instead of comparing master to HEAD
- stop automatic self-release runs on protected master pushes until a PR-based release-commit path exists
- add workflow regression tests and backlog the protected-branch self-release follow-up

## Verification
- actionlint
- /tmp/landfall-gate-venv/bin/python -m pytest -q tests/
- /tmp/landfall-gate-venv/bin/python -m ruff check scripts/ tests/
- /tmp/landfall-gate-venv/bin/python scripts/check-action-contract.py
- /tmp/landfall-gate-venv/bin/python scripts/check-version-sync.py --reference origin/master
- /tmp/landfall-gate-venv/bin/python scripts/replay-action.py --evidence-dir /tmp/landfall-replay-evidence-ci-fix
- /tmp/landfall-gate-venv/bin/python -m check_jsonschema --schemafile https://json.schemastore.org/github-action.json action.yml
- git diff --check

## Reviews
- Grok: NO BLOCKERS
- Claude: NO BLOCKERS; accepted hardening to limit TruffleHog push trigger to protected master and clarify manual release caveat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now requires manual triggering instead of automatic pushes
  * Secret scanning workflow improved to intelligently handle both push and pull request events

* **Documentation**
  * Added clarification on manual release process requirements due to branch protection
  * Documented planned PR-based self-release workflow

* **Tests**
  * Added verification tests for workflow configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->