### PR TITLE
Add consumer replay harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,30 @@ jobs:
         shell: bash
         run: python -m pytest -q tests/
 
-      - name: Replay release integrity policy
+      - name: Replay Landfall action behavior
         shell: bash
-        run: python scripts/replay-action.py --evidence-dir .landfall/replay
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            python scripts/replay-action.py \
+              --evidence-dir .landfall/replay \
+              --scenario action_static_contract \
+              --scenario consumer_full_mode_success \
+              --scenario consumer_synthesis_only_success \
+              --scenario consumer_degraded_required_fails \
+              --scenario consumer_release_update_failure \
+              --scenario consumer_floating_tag_behavior
+          else
+            python scripts/replay-action.py --evidence-dir .landfall/replay
+          fi
+
+      - name: Upload replay evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: landfall-replay-evidence
+          path: .landfall/replay/
+          if-no-files-found: ignore
 
       - name: Validate action metadata
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.py[cod]
 node_modules/
+.landfall/

--- a/README.md
+++ b/README.md
@@ -313,6 +313,28 @@ The public action contract is checked from `action.yml`:
 - The same command scans examples, project docs, and release workflows for unknown or deprecated Landfall inputs.
 - CI runs the contract check before tests so stale consumer instructions fail fast.
 
+### Consumer Replay Harness (Landfall Repo)
+
+Landfall's replay harness creates disposable git fixture repositories and fake
+local GitHub/LLM endpoints, then exercises synthesis, release-body updates,
+artifact writing, failure policy, and floating-tag behavior without production
+secrets:
+
+```bash
+python scripts/replay-action.py --evidence-dir .landfall/replay
+```
+
+The command writes `.landfall/replay/replay-result.json` with action outputs,
+generated notes, release body before/after state, git tags, structured logs, and
+fake service requests. CI runs a bounded replay on pull requests, the full replay
+on `master`, and uploads the evidence packet for inspection.
+
+For a local one-command gate that creates its own Python tool environment, run:
+
+```bash
+bin/gate
+```
+
 ## Custom semantic-release Config
 
 Landfall ships a default config at `configs/.releaserc.json`. If your repo has its own semantic-release config file (`.releaserc`, `.releaserc.json`, `.releaserc.yml`, `.releaserc.yaml`, `release.config.js`, `release.config.cjs`, or `release.config.mjs`), Landfall uses it instead of the bundled defaults.

--- a/backlog.d/003-build-a-live-consumer-replay-harness.md
+++ b/backlog.d/003-build-a-live-consumer-replay-harness.md
@@ -1,16 +1,16 @@
 # Build a live consumer replay harness
 
-Priority: P1 · Status: pending · Estimate: XL
+Priority: P1 · Status: done · Estimate: XL
 
 ## Goal
 Prove Landfall behavior in realistic consumer repositories before release, not only through script unit tests and string checks.
 
 ## Oracle
-- [ ] One local command creates disposable fixture repositories and replays full mode, synthesis-only mode, failure paths, and floating-tag behavior without real secrets.
-- [ ] The harness captures an evidence packet: generated release notes, mutated release body, git refs/tags, action outputs, and structured failure logs.
-- [ ] CI runs a bounded version of the harness on pull requests and the full packet on `master`.
-- [ ] The dogfood release workflow is validated through the same harness shape rather than bespoke assertions.
-- [ ] Local setup is reproducible from one command without relying on whatever packages happen to be installed globally.
+- [x] One local command creates disposable fixture repositories and replays full mode, synthesis-only mode, failure paths, and floating-tag behavior without real secrets.
+- [x] The harness captures an evidence packet: generated release notes, mutated release body, git refs/tags, action outputs, and structured failure logs.
+- [x] CI runs a bounded version of the harness on pull requests and the full packet on `master`.
+- [x] The dogfood release workflow is validated through the same harness shape rather than bespoke assertions.
+- [x] Local setup is reproducible from one command without relying on whatever packages happen to be installed globally.
 
 ## Children
 1. Choose the replay substrate: local shell harness, `act`, or a purpose-built Python runner for composite-action steps.
@@ -28,3 +28,14 @@ Prove Landfall behavior in realistic consumer repositories before release, not o
 - Evidence: the verification lane's `python3 -m pytest --collect-only -q -p no:cacheprovider tests/` failed with `ModuleNotFoundError: No module named 'requests'`, so a cold local gate is not self-contained.
 - Evidence: external behavior is spread across GitHub API calls, semantic-release, LLM HTTP calls, git tag movement, artifact commits, Slack, webhooks, and RSS.
 - Why: verification perspective found the highest-risk failures live between scripts and GitHub Actions orchestration.
+
+## Delivery
+- Expanded `scripts/replay-action.py` from policy/static checks into a consumer
+  replay harness with disposable git fixtures and local fake GitHub/LLM services.
+- Added scenarios for full mode, synthesis-only mode, degraded strict failure,
+  release-body update failure, and floating-tag behavior.
+- Replay evidence now includes action outputs, generated notes, release body
+  before/after, git tags, artifacts, structured logs, and fake service requests.
+- CI runs a bounded replay on pull requests, the full replay on `master`, and
+  uploads `.landfall/replay/` as an artifact.
+- Added `bin/gate` as the local one-command verification loop.

--- a/bin/gate
+++ b/bin/gate
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+VENV_DIR="${LANDFALL_GATE_VENV:-${TMPDIR:-/tmp}/landfall-gate-venv}"
+
+cd "${ROOT}"
+
+"${PYTHON_BIN}" -m venv "${VENV_DIR}"
+"${VENV_DIR}/bin/python" -m pip install --upgrade pip
+"${VENV_DIR}/bin/python" -m pip install "requests==2.34.2" pytest ruff check-jsonschema
+
+npm ci --no-fund --no-audit
+"${VENV_DIR}/bin/python" -m ruff check scripts/ tests/
+tag_ref="HEAD"
+if git remote get-url origin >/dev/null 2>&1; then
+  git fetch --tags --force origin master
+  tag_ref="origin/master"
+fi
+"${VENV_DIR}/bin/python" scripts/check-version-sync.py --reference "${tag_ref}"
+"${VENV_DIR}/bin/python" scripts/check-action-contract.py
+"${VENV_DIR}/bin/python" -m pytest -q tests/
+"${VENV_DIR}/bin/python" scripts/replay-action.py --evidence-dir .landfall/replay
+"${VENV_DIR}/bin/python" -m check_jsonschema --schemafile https://json.schemastore.org/github-action.json action.yml
+
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint
+else
+  echo "warning: actionlint not found; install actionlint for local workflow lint parity" >&2
+fi
+
+git diff --check

--- a/scripts/replay-action.py
+++ b/scripts/replay-action.py
@@ -1,21 +1,71 @@
 #!/usr/bin/env python3
-"""Replay Landfall release-integrity action policy scenarios."""
+"""Replay Landfall action behavior in disposable consumer fixtures."""
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
+import threading
 from pathlib import Path
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+from urllib.parse import unquote
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ACTION_PATH = REPO_ROOT / "action.yml"
 POLICY_SCRIPT = REPO_ROOT / "scripts" / "release-policy.py"
 SYNC_V1_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "sync-v1-tag.yml"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+VALID_NOTES = """## Improvements
+
+- Added a replay harness that checks release behavior in a disposable repo.
+- Captured release body updates, artifacts, tags, and structured logs.
+- Kept the run local so no production secrets or GitHub releases are touched.
+"""
+INVALID_NOTES = "hello, here are the release notes"
+
+
+class ReplayCommandError(RuntimeError):
+    def __init__(self, command: list[str], result: subprocess.CompletedProcess[str]):
+        self.command = command
+        self.result = result
+        super().__init__(f"{' '.join(command)} exited {result.returncode}")
+
+
+class FakeServiceState:
+    def __init__(
+        self,
+        *,
+        llm_status: int = 200,
+        llm_notes: str = VALID_NOTES,
+        update_status: int = 200,
+    ) -> None:
+        self.llm_status = llm_status
+        self.llm_notes = llm_notes
+        self.update_status = update_status
+        self.releases: dict[str, dict[str, Any]] = {}
+        self.requests: list[dict[str, Any]] = []
+
+    def add_release(self, tag: str, body: str) -> None:
+        release_id = len(self.releases) + 1
+        self.releases[tag] = {
+            "id": release_id,
+            "tag_name": tag,
+            "body": body,
+            "html_url": f"https://example.invalid/releases/{tag}",
+        }
+
+    def release_by_id(self, release_id: int) -> dict[str, Any] | None:
+        for release in self.releases.values():
+            if release["id"] == release_id:
+                return release
+        return None
 
 
 def parse_args() -> argparse.Namespace:
@@ -24,6 +74,12 @@ def parse_args() -> argparse.Namespace:
         "--evidence-dir",
         default="",
         help="Directory for replay-result.json. Defaults to a temporary directory.",
+    )
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        default=[],
+        help="Scenario name to run. May be passed multiple times. Defaults to all scenarios.",
     )
     return parser.parse_args()
 
@@ -57,6 +113,482 @@ def run_policy(*args: str) -> dict[str, str]:
 def assert_equal(actual: Any, expected: Any, message: str) -> None:
     if actual != expected:
         raise AssertionError(f"{message}: expected {expected!r}, got {actual!r}")
+
+
+def run_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    process_env = os.environ.copy()
+    if env:
+        process_env.update(env)
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=process_env,
+        text=True,
+        capture_output=True,
+    )
+    if check and result.returncode != 0:
+        raise ReplayCommandError(command, result)
+    return result
+
+
+def run_script(
+    script_name: str,
+    *args: str,
+    cwd: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return run_command([sys.executable, str(SCRIPTS_DIR / script_name), *args], cwd=cwd, check=check)
+
+
+def command_receipt(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    return {
+        "returncode": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def init_fixture_repo(path: Path, *, name: str, release_tag: str, changelog: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    run_command(["git", "init", "-q"], cwd=path)
+    run_command(["git", "config", "user.name", "Landfall Replay"], cwd=path)
+    run_command(["git", "config", "user.email", "replay@example.invalid"], cwd=path)
+    (path / "README.md").write_text(f"# {name}\n", encoding="utf-8")
+    (path / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+    run_command(["git", "add", "."], cwd=path)
+    run_command(["git", "commit", "-q", "-m", "feat: seed replay fixture"], cwd=path)
+    run_command(["git", "tag", release_tag], cwd=path)
+
+
+def git_tags(path: Path) -> list[str]:
+    result = run_command(["git", "tag", "--list", "--sort=refname"], cwd=path)
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_fake_handler(state: FakeServiceState) -> type[BaseHTTPRequestHandler]:
+    class FakeHandler(BaseHTTPRequestHandler):
+        def _record(self, body: str = "") -> None:
+            state.requests.append({"method": self.command, "path": self.path, "body": body})
+
+        def _json(self, status: int, payload: Any) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def _text(self, status: int, body: str) -> None:
+            raw = body.encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+        def do_GET(self) -> None:  # noqa: N802
+            self._record()
+            marker = "/releases/tags/"
+            if marker not in self.path:
+                self._text(404, "not found")
+                return
+            tag = unquote(self.path.rsplit(marker, 1)[1])
+            release = state.releases.get(tag)
+            if release is None:
+                self._json(404, {"message": "Not Found"})
+                return
+            self._json(200, release)
+
+        def do_PATCH(self) -> None:  # noqa: N802
+            raw = self.rfile.read(int(self.headers.get("Content-Length", "0"))).decode("utf-8")
+            self._record(raw)
+            if state.update_status >= 400:
+                self._json(state.update_status, {"message": "update failed"})
+                return
+            try:
+                release_id = int(self.path.rsplit("/releases/", 1)[1])
+            except (IndexError, ValueError):
+                self._text(404, "not found")
+                return
+            release = state.release_by_id(release_id)
+            if release is None:
+                self._json(404, {"message": "Not Found"})
+                return
+            payload = json.loads(raw or "{}")
+            if isinstance(payload.get("body"), str):
+                release["body"] = payload["body"]
+            self._json(200, release)
+
+        def do_POST(self) -> None:  # noqa: N802
+            raw = self.rfile.read(int(self.headers.get("Content-Length", "0"))).decode("utf-8")
+            self._record(raw)
+            if self.path != "/chat/completions":
+                self._text(404, "not found")
+                return
+            if state.llm_status >= 400:
+                self._json(state.llm_status, {"error": {"message": "fake LLM failure"}})
+                return
+            self._json(
+                200,
+                {"choices": [{"message": {"content": state.llm_notes}}]},
+            )
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    return FakeHandler
+
+
+@contextlib.contextmanager
+def fake_service(state: FakeServiceState):
+    server = ThreadingHTTPServer(("127.0.0.1", 0), build_fake_handler(state))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def synthesize_notes(
+    *,
+    repo: Path,
+    api_url: str,
+    release_tag: str,
+    changelog_source: str,
+    quality_path: Path,
+    technical_changelog: Path | None = None,
+    release_body: Path | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    args = [
+        "--api-key",
+        "fake-key",
+        "--api-url",
+        f"{api_url}/chat/completions",
+        "--model",
+        "fake/local",
+        "--version",
+        release_tag,
+        "--changelog-source",
+        changelog_source,
+        "--quality-file",
+        str(quality_path),
+        "--timeout",
+        "2",
+        "--retries",
+        "0",
+        "--retry-backoff",
+        "0",
+    ]
+    if technical_changelog is not None:
+        args.extend(["--technical-changelog-file", str(technical_changelog)])
+    if release_body is not None:
+        args.extend(["--release-body-file", str(release_body)])
+    return run_script("synthesize.py", *args, cwd=repo, check=check)
+
+
+def update_release_body(
+    *,
+    repo: Path,
+    api_url: str,
+    release_tag: str,
+    notes_file: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return run_script(
+        "update-release.py",
+        "--github-token",
+        "fake-token",
+        "--repository",
+        "octo/replay",
+        "--tag",
+        release_tag,
+        "--notes-file",
+        str(notes_file),
+        "--api-base-url",
+        api_url,
+        "--timeout",
+        "2",
+        "--retries",
+        "0",
+        "--retry-backoff",
+        "0",
+        cwd=repo,
+        check=check,
+    )
+
+
+def write_note_artifacts(repo: Path, *, release_tag: str, notes_file: Path) -> subprocess.CompletedProcess[str]:
+    return run_script(
+        "write-artifacts.py",
+        "--notes-file",
+        str(notes_file),
+        "--version",
+        release_tag,
+        "--output-file",
+        "docs/releases/{version}.md",
+        "--output-text-file",
+        "docs/releases/{version}.txt",
+        "--output-html-file",
+        "docs/releases/{version}.html",
+        "--output-json",
+        "docs/releases/index.json",
+        cwd=repo,
+    )
+
+
+def write_synthesis_result(repo: Path, *, release_tag: str, notes: str, quality: str) -> dict[str, str]:
+    notes_path = repo / ".landfall" / "notes.md"
+    notes_path.parent.mkdir(parents=True, exist_ok=True)
+    notes_path.write_text(notes.strip() + "\n", encoding="utf-8")
+    return {
+        "released": "true",
+        "release-tag": release_tag,
+        "synthesis-succeeded": "true" if quality in {"valid", "degraded"} else "false",
+        "synthesis-quality": quality,
+        "release-notes": notes.strip(),
+    }
+
+
+def scenario_consumer_full_mode_success(tmp_root: Path) -> dict[str, Any]:
+    repo = tmp_root / "full-mode-consumer"
+    release_tag = "v1.2.3"
+    changelog = """# Changelog
+
+## 1.2.3
+
+### Features
+- Add a release replay harness for operators.
+"""
+    init_fixture_repo(repo, name="Full Mode Consumer", release_tag=release_tag, changelog=changelog)
+    state = FakeServiceState()
+    state.add_release(release_tag, "## 1.2.3\n\n- Technical release body before synthesis.\n")
+
+    with fake_service(state) as api_url:
+        body_before = state.releases[release_tag]["body"]
+        quality_path = repo / ".landfall" / "quality.txt"
+        synth = synthesize_notes(
+            repo=repo,
+            api_url=api_url,
+            release_tag=release_tag,
+            changelog_source="changelog",
+            quality_path=quality_path,
+        )
+        quality = quality_path.read_text(encoding="utf-8")
+        outputs = write_synthesis_result(repo, release_tag=release_tag, notes=synth.stdout, quality=quality)
+        notes_file = repo / ".landfall" / "notes.md"
+        update = update_release_body(repo=repo, api_url=api_url, release_tag=release_tag, notes_file=notes_file)
+        artifacts = write_note_artifacts(repo, release_tag=release_tag, notes_file=notes_file)
+        floating = run_script("update-floating-tag.py", "--release-tag", release_tag, cwd=repo)
+        run_command(["git", "tag", "-f", floating.stdout.strip(), release_tag], cwd=repo)
+        body_after = state.releases[release_tag]["body"]
+
+    assert_equal(quality, "valid", "full mode quality")
+    assert "## What's New" in body_after
+    assert "Technical release body before synthesis" in body_after
+    return {
+        "fixture": str(repo),
+        "mode": "full",
+        "action_outputs": outputs,
+        "release_body_before": body_before,
+        "release_body_after": body_after,
+        "generated_release_notes": synth.stdout.strip(),
+        "tags": git_tags(repo),
+        "artifacts": {
+            "markdown": (repo / "docs" / "releases" / f"{release_tag}.md").read_text(encoding="utf-8").strip(),
+            "json": json.loads((repo / "docs" / "releases" / "index.json").read_text(encoding="utf-8")),
+        },
+        "commands": {
+            "synthesize": command_receipt(synth),
+            "update_release": command_receipt(update),
+            "write_artifacts": command_receipt(artifacts),
+            "floating_tag": command_receipt(floating),
+        },
+        "fake_service_requests": state.requests,
+    }
+
+
+def scenario_consumer_synthesis_only_success(tmp_root: Path) -> dict[str, Any]:
+    repo = tmp_root / "synthesis-only-consumer"
+    release_tag = "v0.0.0"
+    init_fixture_repo(
+        repo,
+        name="Synthesis Only Consumer",
+        release_tag=release_tag,
+        changelog="# Changelog\n\n## 0.0.0\n\n- Manual release fixture.\n",
+    )
+    state = FakeServiceState()
+    release_body_text = "## 0.0.0\n\n- Release body fallback source.\n"
+    state.add_release(release_tag, release_body_text)
+    release_body_file = repo / ".landfall" / "release-body.md"
+    release_body_file.parent.mkdir(parents=True, exist_ok=True)
+    release_body_file.write_text(release_body_text, encoding="utf-8")
+
+    with fake_service(state) as api_url:
+        quality_path = repo / ".landfall" / "quality.txt"
+        synth = synthesize_notes(
+            repo=repo,
+            api_url=api_url,
+            release_tag=release_tag,
+            changelog_source="release-body",
+            quality_path=quality_path,
+            release_body=release_body_file,
+        )
+        quality = quality_path.read_text(encoding="utf-8")
+        outputs = write_synthesis_result(repo, release_tag=release_tag, notes=synth.stdout, quality=quality)
+        notes_file = repo / ".landfall" / "notes.md"
+        update = update_release_body(repo=repo, api_url=api_url, release_tag=release_tag, notes_file=notes_file)
+
+    assert_equal(quality, "valid", "synthesis-only quality")
+    return {
+        "fixture": str(repo),
+        "mode": "synthesis-only",
+        "action_outputs": outputs,
+        "release_body_after": state.releases[release_tag]["body"],
+        "generated_release_notes": synth.stdout.strip(),
+        "tags": git_tags(repo),
+        "commands": {
+            "synthesize": command_receipt(synth),
+            "update_release": command_receipt(update),
+        },
+        "fake_service_requests": state.requests,
+    }
+
+
+def scenario_consumer_degraded_required_fails(tmp_root: Path) -> dict[str, Any]:
+    repo = tmp_root / "degraded-required-consumer"
+    release_tag = "v2.0.0"
+    init_fixture_repo(
+        repo,
+        name="Degraded Required Consumer",
+        release_tag=release_tag,
+        changelog="# Changelog\n\n## 2.0.0\n\n- Breaking replay fixture.\n",
+    )
+    state = FakeServiceState(llm_notes=INVALID_NOTES)
+
+    with fake_service(state) as api_url:
+        quality_path = repo / ".landfall" / "quality.txt"
+        synth = synthesize_notes(
+            repo=repo,
+            api_url=api_url,
+            release_tag=release_tag,
+            changelog_source="changelog",
+            quality_path=quality_path,
+        )
+        quality = quality_path.read_text(encoding="utf-8")
+        policy = run_policy(
+            "publication",
+            "--synthesis-required",
+            "true",
+            "--synthesis-strict",
+            "false",
+            "--synth-succeeded",
+            "true",
+            "--synth-quality",
+            quality,
+        )
+
+    assert_equal(quality, "degraded", "required scenario records degraded notes")
+    assert_equal(policy["can_update_release"], "false", "required degraded notes cannot update release")
+    return {
+        "fixture": str(repo),
+        "mode": "failure",
+        "generated_release_notes": synth.stdout.strip(),
+        "quality": quality,
+        "policy_outputs": policy,
+        "structured_failure_logs": synth.stderr.strip().splitlines(),
+        "fake_service_requests": state.requests,
+    }
+
+
+def scenario_consumer_release_update_failure(tmp_root: Path) -> dict[str, Any]:
+    repo = tmp_root / "update-failure-consumer"
+    release_tag = "v3.1.4"
+    init_fixture_repo(
+        repo,
+        name="Update Failure Consumer",
+        release_tag=release_tag,
+        changelog="# Changelog\n\n## 3.1.4\n\n- Patch replay fixture.\n",
+    )
+    state = FakeServiceState(update_status=500)
+    state.add_release(release_tag, "## 3.1.4\n\n- Existing body.\n")
+
+    with fake_service(state) as api_url:
+        quality_path = repo / ".landfall" / "quality.txt"
+        synth = synthesize_notes(
+            repo=repo,
+            api_url=api_url,
+            release_tag=release_tag,
+            changelog_source="changelog",
+            quality_path=quality_path,
+        )
+        outputs = write_synthesis_result(
+            repo,
+            release_tag=release_tag,
+            notes=synth.stdout,
+            quality=quality_path.read_text(encoding="utf-8"),
+        )
+        notes_file = repo / ".landfall" / "notes.md"
+        update = update_release_body(
+            repo=repo,
+            api_url=api_url,
+            release_tag=release_tag,
+            notes_file=notes_file,
+            check=False,
+        )
+
+    assert_equal(update.returncode, 1, "release update failure exits non-zero")
+    return {
+        "fixture": str(repo),
+        "mode": "failure",
+        "action_outputs": outputs,
+        "release_body_after": state.releases[release_tag]["body"],
+        "commands": {
+            "synthesize": command_receipt(synth),
+            "update_release": command_receipt(update),
+        },
+        "structured_failure_logs": update.stderr.strip().splitlines(),
+        "fake_service_requests": state.requests,
+    }
+
+
+def scenario_consumer_floating_tag_behavior(tmp_root: Path) -> dict[str, Any]:
+    repo = tmp_root / "floating-tag-consumer"
+    init_fixture_repo(
+        repo,
+        name="Floating Tag Consumer",
+        release_tag="v4.5.6",
+        changelog="# Changelog\n\n## 4.5.6\n\n- Stable release.\n",
+    )
+    stable = run_script("update-floating-tag.py", "--release-tag", "v4.5.6", cwd=repo)
+    prerelease = run_script("update-floating-tag.py", "--release-tag", "v4.5.7-rc.1", cwd=repo)
+    invalid = run_script("update-floating-tag.py", "--release-tag", "not-a-tag", cwd=repo, check=False)
+    run_command(["git", "tag", "-f", stable.stdout.strip(), "v4.5.6"], cwd=repo)
+
+    assert_equal(stable.stdout.strip(), "v4", "stable semver emits major tag")
+    assert_equal(prerelease.stdout.strip(), "", "prerelease does not emit floating tag")
+    assert_equal(invalid.returncode, 1, "invalid tag fails")
+    return {
+        "fixture": str(repo),
+        "stable_output": stable.stdout.strip(),
+        "prerelease_output": prerelease.stdout.strip(),
+        "invalid": command_receipt(invalid),
+        "tags": git_tags(repo),
+    }
 
 
 def scenario_publication_degraded_required() -> dict[str, str]:
@@ -211,7 +743,7 @@ def main() -> int:
         evidence_dir = Path(tempfile.mkdtemp(prefix="landfall-replay-"))
     evidence_dir.mkdir(parents=True, exist_ok=True)
 
-    scenario_fns = {
+    policy_scenario_fns = {
         "publication_degraded_required": scenario_publication_degraded_required,
         "publication_degraded_optional": scenario_publication_degraded_optional,
         "summary_release_update_failed": scenario_summary_release_update_failed,
@@ -219,16 +751,49 @@ def main() -> int:
         "summary_rss_failed": scenario_summary_rss_failed,
         "action_static_contract": scenario_action_static_contract,
     }
-    scenarios: dict[str, dict[str, str]] = {}
+    consumer_scenario_fns = {
+        "consumer_full_mode_success": scenario_consumer_full_mode_success,
+        "consumer_synthesis_only_success": scenario_consumer_synthesis_only_success,
+        "consumer_degraded_required_fails": scenario_consumer_degraded_required_fails,
+        "consumer_release_update_failure": scenario_consumer_release_update_failure,
+        "consumer_floating_tag_behavior": scenario_consumer_floating_tag_behavior,
+    }
+    scenario_fns: dict[str, Any] = {**policy_scenario_fns, **consumer_scenario_fns}
+
+    requested = args.scenario or list(scenario_fns)
+    unknown = [name for name in requested if name not in scenario_fns]
+    if unknown:
+        print(f"unknown replay scenario(s): {', '.join(unknown)}", file=sys.stderr)
+        return 2
+
+    scenarios: dict[str, Any] = {}
     errors: dict[str, str] = {}
-    for name, scenario_fn in scenario_fns.items():
-        try:
-            scenarios[name] = scenario_fn()
-        except AssertionError as exc:
-            errors[name] = str(exc)
+    with tempfile.TemporaryDirectory(prefix="landfall-consumer-replay-") as tmp:
+        tmp_root = Path(tmp)
+        for name in requested:
+            scenario_fn = scenario_fns[name]
+            try:
+                if name in consumer_scenario_fns:
+                    scenarios[name] = scenario_fn(tmp_root)
+                else:
+                    scenarios[name] = scenario_fn()
+            except (AssertionError, ReplayCommandError) as exc:
+                if isinstance(exc, ReplayCommandError):
+                    errors[name] = json.dumps(
+                        {
+                            "error": str(exc),
+                            "returncode": exc.result.returncode,
+                            "stdout": exc.result.stdout.strip(),
+                            "stderr": exc.result.stderr.strip(),
+                        },
+                        sort_keys=True,
+                    )
+                else:
+                    errors[name] = str(exc)
 
     evidence = {
         "verdict": "failed" if errors else "passed",
+        "scenario_count": len(requested),
         "scenarios": scenarios,
     }
     if errors:

--- a/scripts/synthesize.py
+++ b/scripts/synthesize.py
@@ -908,7 +908,9 @@ def main() -> int:
 
     def _write_quality(quality: str) -> None:
         if args.quality_file:
-            Path(args.quality_file).write_text(quality, encoding="utf-8")
+            quality_path = Path(args.quality_file)
+            quality_path.parent.mkdir(parents=True, exist_ok=True)
+            quality_path.write_text(quality, encoding="utf-8")
 
     models_to_try = [args.model]
     if args.fallback_models:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,3 +179,8 @@ def release_policy():
 @pytest.fixture(scope="session")
 def fetch_release_body():
     return load_script_module("landfall_fetch_release_body", "scripts/fetch-release-body.py")
+
+
+@pytest.fixture(scope="session")
+def replay_action():
+    return load_script_module("landfall_replay_action", "scripts/replay-action.py")

--- a/tests/test_replay_action.py
+++ b/tests/test_replay_action.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def test_replay_action_selected_consumer_scenarios_write_evidence(repo_root: Path, tmp_path: Path) -> None:
+    evidence_dir = tmp_path / "evidence"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts" / "replay-action.py"),
+            "--evidence-dir",
+            str(evidence_dir),
+            "--scenario",
+            "consumer_full_mode_success",
+            "--scenario",
+            "consumer_degraded_required_fails",
+        ],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    evidence_path = evidence_dir / "replay-result.json"
+    assert str(evidence_path) in result.stdout
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+
+    assert evidence["verdict"] == "passed"
+    assert evidence["scenario_count"] == 2
+
+    full_mode = evidence["scenarios"]["consumer_full_mode_success"]
+    assert full_mode["mode"] == "full"
+    assert full_mode["action_outputs"]["released"] == "true"
+    assert full_mode["action_outputs"]["synthesis-quality"] == "valid"
+    assert "## What's New" in full_mode["release_body_after"]
+    assert "v1" in full_mode["tags"]
+    assert full_mode["artifacts"]["json"][0]["version"] == "1.2.3"
+
+    degraded = evidence["scenarios"]["consumer_degraded_required_fails"]
+    assert degraded["quality"] == "degraded"
+    assert degraded["policy_outputs"]["can_update_release"] == "false"
+    assert degraded["structured_failure_logs"]
+
+
+def test_replay_action_rejects_unknown_scenario(repo_root: Path, tmp_path: Path) -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts" / "replay-action.py"),
+            "--evidence-dir",
+            str(tmp_path),
+            "--scenario",
+            "missing",
+        ],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "unknown replay scenario(s): missing" in result.stderr
+
+
+def test_fake_service_updates_release_body(replay_action) -> None:
+    state = replay_action.FakeServiceState()
+    state.add_release("v1.0.0", "old")
+
+    with replay_action.fake_service(state) as api_url:
+        release_response = urllib.request.urlopen(f"{api_url}/repos/octo/replay/releases/tags/v1.0.0", timeout=2)
+        release = json.loads(release_response.read().decode("utf-8"))
+        assert release["body"] == "old"
+
+        request = urllib.request.Request(
+            f"{api_url}/repos/octo/replay/releases/1",
+            data=json.dumps({"body": "new"}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="PATCH",
+        )
+        update_response = urllib.request.urlopen(request, timeout=2)
+        updated = json.loads(update_response.read().decode("utf-8"))
+
+    assert updated["body"] == "new"
+    assert state.releases["v1.0.0"]["body"] == "new"

--- a/tests/test_synthesize.py
+++ b/tests/test_synthesize.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import logging
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -1059,3 +1061,44 @@ class TestSynthesisRetryOnValidation:
 
         assert quality == "degraded"
         assert notes == bad_notes.strip()
+
+
+def test_main_creates_quality_file_parent(repo_root, tmp_path):
+    template = tmp_path / "prompt.md"
+    template.write_text(
+        "{{PRODUCT_NAME}} {{VERSION}}\n\n{{TECHNICAL_CHANGELOG}}",
+        encoding="utf-8",
+    )
+    technical = tmp_path / "technical.md"
+    technical.write_text("- Fixed local replay quality output.\n", encoding="utf-8")
+    quality_file = tmp_path / "nested" / "quality.txt"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts" / "synthesize.py"),
+            "--api-key",
+            "fake",
+            "--api-url",
+            "http://127.0.0.1:1/chat/completions",
+            "--model",
+            "fake/local",
+            "--prompt-template",
+            str(template),
+            "--technical-changelog-file",
+            str(technical),
+            "--quality-file",
+            str(quality_file),
+            "--timeout",
+            "1",
+            "--retries",
+            "0",
+        ],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert quality_file.read_text(encoding="utf-8") == "failed"


### PR DESCRIPTION
## Summary
- expand replay-action into a consumer replay harness with disposable git fixtures and local fake GitHub/LLM endpoints
- cover full mode, synthesis-only mode, degraded strict failure, release update failure, and floating-tag behavior
- add bin/gate, CI replay artifact upload, docs, and backlog closeout for ticket 003
- harden synthesize quality-file writes for nested evidence paths

## Verification
- bin/gate
- GITHUB_EVENT_NAME=pull_request /tmp/landfall-gate-venv/bin/python scripts/replay-action.py --evidence-dir /tmp/landfall-replay-003-pr --scenario action_static_contract --scenario consumer_full_mode_success --scenario consumer_synthesis_only_success --scenario consumer_degraded_required_fails --scenario consumer_release_update_failure --scenario consumer_floating_tag_behavior
- actionlint

## Evidence
- .landfall/replay/replay-result.json: passed, 11 scenarios
- /tmp/landfall-replay-003-pr/replay-result.json: passed, 6 PR-bounded scenarios

## Reviews
- QA agent initially found a PR CI coverage blocker; fixed by adding full-mode and release-update-failure scenarios to the PR replay set
- QA re-check: PASS, no blockers
- Adversarial review: NO BLOCKERS; residual bin/gate origin/master note fixed by fetching origin when available and falling back to HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consumer replay harness with multiple test scenarios to exercise release workflows.
  * CI now uploads replay evidence artifacts for inspection.
  * Added local verification gate command for testing.

* **Bug Fixes**
  * Fixed directory creation during synthesis output.

* **Documentation**
  * Added replay harness overview to README.
  * Updated backlog with completed replay harness scope.

* **Tests**
  * Added comprehensive test suite for replay harness and synthesis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->