### PR TITLE
feat(notes): add typed release note artifact plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ Landfall is language-agnostic. Your repo does not need `package.json` or Node.js
 | `release-tag` | Tag created by `semantic-release` (empty if no release). |
 | `synthesis-succeeded` | `true` only when synthesis and release-body update both succeed for the released tag. |
 | `synthesis-quality` | `valid`, `degraded`, or `failed`. |
+| `synthesis-status` | Compact JSON status with quality, failure stage/message, model attempts, and publication destination outcomes. |
 | `release-notes` | Synthesized user-facing release notes markdown. Empty if synthesis was skipped or failed. |
 | `webhook-sent` | `true` when the generic webhook notification was sent successfully. |
 | `slack-sent` | `true` when the Slack notification was sent successfully. |
+| `synthesis-failure-issue-action` | Companion failure-issue lifecycle result: `closed`, `reported`, `failed`, or `skipped`. |
 
 ## Release Integrity Policy
 
@@ -222,18 +224,60 @@ For private repos where GitHub Releases aren't publicly visible, use artifact ou
     notes-output-json: releases.json
 ```
 
-This writes per-version markdown files and maintains a JSON feed for changelog pages:
+This writes per-version markdown files and maintains a typed JSON artifact feed for changelog pages:
 
 ```json
 [
   {
     "version": "1.2.0",
-    "date": "2026-02-08",
+    "tag": "v1.2.0",
     "notes": "## New Features\n- ...",
-    "notes_plaintext": "New Features\n\n- ...",
-    "notes_html": "<h2>New Features</h2>\n<ul>\n<li>...</li>\n</ul>"
+    "markdown": "## New Features\n- ...",
+    "plaintext": "New Features\n...",
+    "html": "<h2>New Features</h2>\n<ul>\n<li>...</li>\n</ul>",
+    "slack": "## New Features\n- ...",
+    "sections": [
+      {
+        "title": "New Features",
+        "bullets": [
+          {
+            "text": "...",
+            "links": []
+          }
+        ]
+      }
+    ],
+    "published_at": "2026-02-08T12:00:00Z"
   }
 ]
+```
+
+The `synthesis-status` output is a compact JSON object for automation:
+
+```json
+{
+  "synthesis_enabled": true,
+  "released": true,
+  "succeeded": true,
+  "quality": "valid",
+  "failure_stage": "",
+  "failure_message": "",
+  "model_attempts": [
+    {
+      "model": "anthropic/claude-sonnet-4",
+      "succeeded": true,
+      "quality": "valid",
+      "message": ""
+    }
+  ],
+  "destinations": {
+    "release_body": { "enabled": true, "succeeded": true, "failure_stage": "", "failure_message": "" },
+    "artifacts": { "enabled": true, "succeeded": true, "failure_stage": "", "failure_message": "" },
+    "rss": { "enabled": false, "succeeded": false, "failure_stage": "", "failure_message": "" },
+    "webhook": { "enabled": false, "succeeded": false, "failure_stage": "", "failure_message": "" },
+    "slack": { "enabled": false, "succeeded": false, "failure_stage": "", "failure_message": "" }
+  }
+}
 ```
 
 ## RSS Release Feed

--- a/action.yml
+++ b/action.yml
@@ -129,12 +129,18 @@ outputs:
   synthesis-quality:
     description: "Quality of synthesized output: valid (passed validation), degraded (validation failed, using unvalidated output), or failed (synthesis itself failed)."
     value: ${{ steps.synthesis_result.outputs.quality }}
+  synthesis-status:
+    description: Machine-readable JSON status for synthesis, model attempts, and publication destinations.
+    value: ${{ steps.synthesis_result.outputs.status_json }}
   webhook-sent:
     description: Whether the webhook notification was sent successfully.
     value: ${{ steps.notify_webhook.outputs.sent || 'false' }}
   slack-sent:
     description: Whether the Slack notification was sent successfully.
     value: ${{ steps.notify_slack.outputs.sent || 'false' }}
+  synthesis-failure-issue-action:
+    description: "Companion issue lifecycle result: closed, reported, failed, or skipped."
+    value: ${{ steps.close_failure_issues.outputs.action || steps.report_synthesis_failure.outputs.action || 'skipped' }}
 
 runs:
   using: composite
@@ -411,7 +417,9 @@ runs:
         fi
 
         quality_file="${RUNNER_TEMP}/landfall-synthesis-quality.txt"
+        attempts_file="${RUNNER_TEMP}/landfall-synthesis-attempts.json"
         synth_log="${RUNNER_TEMP}/landfall-synthesize.log"
+        set_output "attempts_file" "${attempts_file}"
         synth_source_args=()
         if [ -n "${release_body_file}" ]; then
           synth_source_args+=(--release-body-file "${release_body_file}")
@@ -437,6 +445,7 @@ runs:
           "${synth_source_args[@]}" \
           --templates-dir "${GITHUB_ACTION_PATH}/templates/prompts" \
           --quality-file "${quality_file}" \
+          --attempts-file "${attempts_file}" \
           > "${notes_file}" \
           2> "${synth_log}"; then
           details="$(tail -n 5 "${synth_log}" | tr '\r\n' ' ' | sed -E 's/[[:space:]]+/ /g' | sed -E 's/^ +| +$//g')"
@@ -807,6 +816,11 @@ runs:
         RSS_STEP_SUCCEEDED: ${{ steps.update_rss.outputs.succeeded }}
         RSS_FAILURE_STAGE: ${{ steps.update_rss.outputs.failure_stage }}
         RSS_FAILURE_MESSAGE: ${{ steps.update_rss.outputs.failure_message }}
+        WEBHOOK_ENABLED: ${{ inputs.webhook-url != '' }}
+        WEBHOOK_SENT: ${{ steps.notify_webhook.outputs.sent }}
+        SLACK_ENABLED: ${{ inputs.slack-webhook-url != '' }}
+        SLACK_SENT: ${{ steps.notify_slack.outputs.sent }}
+        MODEL_ATTEMPTS_FILE: ${{ steps.synthesize.outputs.attempts_file }}
       run: |
         set -euo pipefail
         "${GITHUB_ACTION_PATH}/dist/landfall" release-policy summary \
@@ -826,6 +840,11 @@ runs:
           --rss-succeeded "${RSS_STEP_SUCCEEDED}" \
           --rss-failure-stage "${RSS_FAILURE_STAGE}" \
           --rss-failure-message "${RSS_FAILURE_MESSAGE}" \
+          --webhook-enabled "${WEBHOOK_ENABLED}" \
+          --webhook-sent "${WEBHOOK_SENT}" \
+          --slack-enabled "${SLACK_ENABLED}" \
+          --slack-sent "${SLACK_SENT}" \
+          --attempts-file "${MODEL_ATTEMPTS_FILE}" \
           --github-output "${GITHUB_OUTPUT}"
 
     - name: Update floating major tag
@@ -878,6 +897,7 @@ runs:
         fi
 
     - name: Close resolved synthesis failure issues
+      id: close_failure_issues
       if: inputs.synthesis == 'true' && steps.resolve_release.outputs.released == 'true' && inputs.synthesis-failure-issue == 'true' && steps.synthesis_result.outputs.succeeded == 'true'
       shell: bash
       env:
@@ -885,14 +905,23 @@ runs:
         RELEASE_TAG: ${{ steps.resolve_release.outputs.release_tag }}
       run: |
         set -euo pipefail
-        if ! "${GITHUB_ACTION_PATH}/dist/landfall" close-resolved-failures \
+        set_output() {
+          local key="$1"
+          local value="$2"
+          printf '%s=%s\n' "${key}" "${value}" >> "${GITHUB_OUTPUT}"
+        }
+        if "${GITHUB_ACTION_PATH}/dist/landfall" close-resolved-failures \
           --github-token "${GITHUB_TOKEN}" \
           --repository "${GITHUB_REPOSITORY}" \
           --release-tag "${RELEASE_TAG}"; then
+          set_output "action" "closed"
+        else
           echo "::warning::Landfall could not close resolved failure issues."
+          set_output "action" "failed"
         fi
 
     - name: Report synthesis failure
+      id: report_synthesis_failure
       if: inputs.synthesis == 'true' && steps.resolve_release.outputs.released == 'true' && inputs.synthesis-failure-issue == 'true' && steps.synthesis_result.outputs.succeeded != 'true' && steps.synthesis_result.outputs.failure_stage != 'configuration'
       shell: bash
       env:
@@ -902,8 +931,13 @@ runs:
         RELEASE_TAG: ${{ steps.resolve_release.outputs.release_tag }}
       run: |
         set -euo pipefail
+        set_output() {
+          local key="$1"
+          local value="$2"
+          printf '%s=%s\n' "${key}" "${value}" >> "${GITHUB_OUTPUT}"
+        }
         run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-        if ! "${GITHUB_ACTION_PATH}/dist/landfall" report-synthesis-failure \
+        if "${GITHUB_ACTION_PATH}/dist/landfall" report-synthesis-failure \
           --github-token "${GITHUB_TOKEN}" \
           --repository "${GITHUB_REPOSITORY}" \
           --release-tag "${RELEASE_TAG}" \
@@ -911,7 +945,10 @@ runs:
           --workflow-name "${GITHUB_WORKFLOW}" \
           --failure-stage "${FAILURE_STAGE}" \
           --failure-message "${FAILURE_MESSAGE}"; then
+          set_output "action" "reported"
+        else
           echo "::warning::Landfall could not create a synthesis failure issue."
+          set_output "action" "failed"
         fi
 
     - name: Enforce synthesis required

--- a/backlog.d/005-turn-release-notes-into-a-typed-artifact-plane.md
+++ b/backlog.d/005-turn-release-notes-into-a-typed-artifact-plane.md
@@ -1,16 +1,16 @@
 # Turn release notes into a typed artifact plane
 
-Priority: P2 · Status: pending · Estimate: L
+Priority: P2 · Status: done · Estimate: L
 
 ## Goal
 Consolidate release-note rendering, notification payloads, and machine-readable diagnostics around typed note artifacts instead of parallel markdown parsers and ad hoc outputs.
 
 ## Oracle
-- [ ] A shared note model can render markdown, plaintext, HTML, Slack Block Kit text, RSS entries, webhook JSON, and stored JSON without duplicated parsing rules.
-- [ ] Unsafe link handling is implemented once and covered by shared tests.
-- [ ] Consumers can subscribe to a stable machine-readable synthesis status payload that includes quality, stage, model attempts, and publication destinations.
-- [ ] Failure issue creation/closure is either modeled as an explicit companion output channel or removed from the core action surface.
-- [ ] Existing outputs remain backward-compatible or have a documented deprecation path.
+- [x] A shared note model can render markdown, plaintext, HTML, Slack Block Kit text, RSS entries, webhook JSON, and stored JSON without duplicated parsing rules.
+- [x] Unsafe link handling is implemented once and covered by shared tests.
+- [x] Consumers can subscribe to a stable machine-readable synthesis status payload that includes quality, stage, model attempts, and publication destinations.
+- [x] Failure issue creation/closure is either modeled as an explicit companion output channel or removed from the core action surface.
+- [x] Existing outputs remain backward-compatible or have a documented deprecation path.
 
 ## Children
 1. Introduce a typed release-note artifact module with sections, bullets, links, quality, source, and rendering adapters.
@@ -27,3 +27,10 @@ Consolidate release-note rendering, notification payloads, and machine-readable 
 - Evidence: `action.yml` opens and closes synthesis failure issues from the core release action, expanding permissions and stateful side effects beyond release-note publishing.
 - Evidence: product review found platform consumers need machine-readable synthesis health signals beyond warning text and simple booleans.
 - Why: simplification and platform perspectives converge here: Landfall's value is the note artifact, but that artifact is not yet modeled deeply.
+
+## Delivery
+- Added `ReleaseNoteArtifact` as the shared Rust model for markdown, plaintext, HTML, Slack, RSS, webhook JSON, stored JSON, sections, bullets, and safe links.
+- Added `SynthesisStatus` JSON as the `synthesis-status` action output with quality, failure stage/message, model attempts, and release body/artifact/RSS/webhook/Slack destination outcomes.
+- Added `synthesis-failure-issue-action` as the explicit companion output channel for failure issue close/report/failure/skipped states.
+- Preserved existing scalar outputs and stored JSON compatibility, including dedupe by both current `tag` and older `version` entries.
+- Verification: `bin/gate`; `cargo test --locked` with 6 tests including typed artifact rendering and status JSON coverage; adversarial Grok review: no blockers; Claude QA: pass; `shasum -a 256 -c dist/landfall.sha256`.

--- a/crates/landfall/src/main.rs
+++ b/crates/landfall/src/main.rs
@@ -3,6 +3,7 @@ use clap::{Args, Parser, Subcommand};
 use hmac::{Hmac, Mac};
 use pulldown_cmark::{Options, Parser as MarkdownParser, html};
 use regex::Regex;
+use serde::Serialize;
 use serde_json::{Value, json};
 use sha2::Sha256;
 use std::collections::{BTreeMap, BTreeSet};
@@ -38,7 +39,7 @@ enum Commands {
     PreflightTags,
     FetchReleaseBody(FetchReleaseBodyArgs),
     ExtractPrs(ExtractPrsArgs),
-    Synthesize(SynthesizeArgs),
+    Synthesize(Box<SynthesizeArgs>),
     ReleasePolicy(ReleasePolicyArgs),
     UpdateRelease(UpdateReleaseArgs),
     WriteArtifacts(WriteArtifactsArgs),
@@ -127,6 +128,8 @@ struct SynthesizeArgs {
     prompt_template: PathBuf,
     #[arg(long = "quality-file")]
     quality_file: PathBuf,
+    #[arg(long = "attempts-file", default_value = ".")]
+    attempts_file: PathBuf,
     #[arg(long = "templates-dir", default_value = "templates/prompts")]
     templates_dir: PathBuf,
 }
@@ -195,8 +198,18 @@ struct SummaryArgs {
     rss_failure_stage: String,
     #[arg(long = "rss-failure-message", default_value = "")]
     rss_failure_message: String,
+    #[arg(long = "webhook-enabled", default_value = "")]
+    webhook_enabled: String,
+    #[arg(long = "webhook-sent", default_value = "")]
+    webhook_sent: String,
+    #[arg(long = "slack-enabled", default_value = "")]
+    slack_enabled: String,
+    #[arg(long = "slack-sent", default_value = "")]
+    slack_sent: String,
     #[arg(long = "github-output")]
     github_output: PathBuf,
+    #[arg(long = "attempts-file", default_value = ".")]
+    attempts_file: PathBuf,
 }
 
 #[derive(Args)]
@@ -364,7 +377,7 @@ fn run() -> Result<()> {
         Commands::PreflightTags => preflight_tags(),
         Commands::FetchReleaseBody(args) => fetch_release_body(args),
         Commands::ExtractPrs(args) => extract_prs(args),
-        Commands::Synthesize(args) => synthesize(args),
+        Commands::Synthesize(args) => synthesize(*args),
         Commands::ReleasePolicy(args) => release_policy(args),
         Commands::UpdateRelease(args) => update_release(args),
         Commands::WriteArtifacts(args) => write_artifacts(args),
@@ -623,6 +636,7 @@ fn synthesize(args: SynthesizeArgs) -> Result<()> {
             .map(str::to_string),
     );
     let mut last_error = String::new();
+    let mut attempts = Vec::new();
     for model in models {
         match request_synthesis(&args.api_url, &args.api_key, &model, &prompt) {
             Ok(notes) if !notes.trim().is_empty() => {
@@ -631,15 +645,39 @@ fn synthesize(args: SynthesizeArgs) -> Result<()> {
                 } else {
                     "degraded"
                 };
+                attempts.push(json!({
+                    "model": model,
+                    "succeeded": true,
+                    "quality": quality,
+                    "message": "",
+                }));
+                write_json_if_requested(&args.attempts_file, &attempts)?;
                 ensure_parent(&args.quality_file)?;
                 fs::write(&args.quality_file, quality)?;
                 println!("{}", notes.trim());
                 return Ok(());
             }
-            Ok(_) => last_error = format!("model {model} returned empty content"),
-            Err(error) => last_error = format!("model {model} failed: {error}"),
+            Ok(_) => {
+                last_error = format!("model {model} returned empty content");
+                attempts.push(json!({
+                    "model": model,
+                    "succeeded": false,
+                    "quality": "failed",
+                    "message": last_error,
+                }));
+            }
+            Err(error) => {
+                last_error = format!("model {model} failed: {error}");
+                attempts.push(json!({
+                    "model": model,
+                    "succeeded": false,
+                    "quality": "failed",
+                    "message": last_error,
+                }));
+            }
         }
     }
+    write_json_if_requested(&args.attempts_file, &attempts)?;
     Err(last_error.into())
 }
 
@@ -853,6 +891,10 @@ fn summary_policy(args: SummaryArgs) -> Result<()> {
     let artifact_succeeded = parse_bool(&args.artifact_succeeded);
     let rss_enabled = parse_bool(&args.rss_enabled);
     let rss_succeeded = parse_bool(&args.rss_succeeded);
+    let webhook_enabled = parse_bool(&args.webhook_enabled);
+    let webhook_sent = parse_bool(&args.webhook_sent);
+    let slack_enabled = parse_bool(&args.slack_enabled);
+    let slack_sent = parse_bool(&args.slack_sent);
     let quality = normalize_quality(&args.synth_quality);
     let (succeeded, failure_stage, failure_message) = if !synthesis_enabled || !released {
         (true, "", "")
@@ -883,6 +925,62 @@ fn summary_policy(args: SummaryArgs) -> Result<()> {
     } else {
         (true, "", "")
     };
+    let mut destinations = BTreeMap::new();
+    destinations.insert(
+        "release_body".to_string(),
+        DestinationStatus {
+            enabled: synthesis_enabled && released && synth_succeeded,
+            succeeded: update_succeeded,
+            failure_stage: sanitize_text(&args.update_failure_stage),
+            failure_message: sanitize_text(&args.update_failure_message),
+        },
+    );
+    destinations.insert(
+        "artifacts".to_string(),
+        DestinationStatus {
+            enabled: synthesis_enabled && released && synth_succeeded && update_succeeded,
+            succeeded: artifact_succeeded,
+            failure_stage: sanitize_text(&args.artifact_failure_stage),
+            failure_message: sanitize_text(&args.artifact_failure_message),
+        },
+    );
+    destinations.insert(
+        "rss".to_string(),
+        DestinationStatus {
+            enabled: rss_enabled,
+            succeeded: rss_succeeded,
+            failure_stage: sanitize_text(&args.rss_failure_stage),
+            failure_message: sanitize_text(&args.rss_failure_message),
+        },
+    );
+    destinations.insert(
+        "webhook".to_string(),
+        DestinationStatus {
+            enabled: webhook_enabled,
+            succeeded: webhook_sent,
+            failure_stage: String::new(),
+            failure_message: String::new(),
+        },
+    );
+    destinations.insert(
+        "slack".to_string(),
+        DestinationStatus {
+            enabled: slack_enabled,
+            succeeded: slack_sent,
+            failure_stage: String::new(),
+            failure_message: String::new(),
+        },
+    );
+    let status = SynthesisStatus {
+        synthesis_enabled,
+        released,
+        succeeded,
+        quality: quality.clone(),
+        failure_stage: sanitize_text(failure_stage),
+        failure_message: sanitize_text(failure_message),
+        model_attempts: read_json_array_if_requested(&args.attempts_file)?,
+        destinations,
+    };
     write_outputs(
         &args.github_output,
         &[
@@ -890,6 +988,7 @@ fn summary_policy(args: SummaryArgs) -> Result<()> {
             ("quality", quality),
             ("failure_stage", sanitize_text(failure_stage)),
             ("failure_message", sanitize_text(failure_message)),
+            ("status_json", serde_json::to_string(&status)?),
         ],
     )
 }
@@ -968,29 +1067,126 @@ fn strip_existing_whats_new(body: &str) -> String {
     output.join("\n").trim().to_string()
 }
 
+#[derive(Clone, Serialize)]
+struct ReleaseNoteArtifact {
+    version: String,
+    tag: String,
+    notes: String,
+    plaintext: String,
+    html: String,
+    slack: String,
+    sections: Vec<NoteSection>,
+    published_at: String,
+}
+
+#[derive(Clone, Serialize)]
+struct NoteSection {
+    title: String,
+    bullets: Vec<NoteBullet>,
+}
+
+#[derive(Clone, Serialize)]
+struct NoteBullet {
+    text: String,
+    links: Vec<NoteLink>,
+}
+
+#[derive(Clone, Serialize)]
+struct NoteLink {
+    label: String,
+    href: String,
+}
+
+impl ReleaseNoteArtifact {
+    fn from_markdown(version: &str, notes: &str) -> Self {
+        let trimmed = notes.trim().to_string();
+        Self {
+            version: version.trim_start_matches('v').to_string(),
+            tag: version.to_string(),
+            plaintext: markdown_to_plaintext(&trimmed),
+            html: markdown_to_html_fragment(&trimmed),
+            slack: markdown_to_slack(&trimmed),
+            sections: parse_note_sections(&trimmed),
+            published_at: Utc::now().to_rfc3339(),
+            notes: trimmed,
+        }
+    }
+
+    fn json_entry(&self) -> Value {
+        json!({
+            "version": self.version,
+            "tag": self.tag,
+            "notes": self.notes,
+            "markdown": self.notes,
+            "html": self.html,
+            "plaintext": self.plaintext,
+            "slack": self.slack,
+            "sections": self.sections,
+            "published_at": self.published_at,
+        })
+    }
+
+    fn webhook_payload(&self, repository: &str, release_url: &str) -> Value {
+        json!({
+            "version": self.tag,
+            "repository": repository,
+            "release_url": release_url,
+            "notes": self.notes,
+            "markdown": self.notes,
+            "html": self.html,
+            "plaintext": self.plaintext,
+            "sections": self.sections,
+            "published_at": self.published_at,
+        })
+    }
+
+    fn slack_payload(&self, repository: &str, release_url: &str) -> Value {
+        json!({
+            "blocks": [
+                {"type": "header", "text": {"type": "plain_text", "text": format!("{} {}", repository, self.tag)}},
+                {"type": "section", "text": {"type": "mrkdwn", "text": self.slack}},
+                {"type": "context", "elements": [{"type": "mrkdwn", "text": format!("<{}|View release>", release_url)}]}
+            ]
+        })
+    }
+}
+
+#[derive(Serialize)]
+struct SynthesisStatus {
+    synthesis_enabled: bool,
+    released: bool,
+    succeeded: bool,
+    quality: String,
+    failure_stage: String,
+    failure_message: String,
+    model_attempts: Vec<Value>,
+    destinations: BTreeMap<String, DestinationStatus>,
+}
+
+#[derive(Serialize)]
+struct DestinationStatus {
+    enabled: bool,
+    succeeded: bool,
+    failure_stage: String,
+    failure_message: String,
+}
+
 fn write_artifacts(args: WriteArtifactsArgs) -> Result<()> {
     let notes = read_nonempty(&args.notes_file)?;
+    let artifact = ReleaseNoteArtifact::from_markdown(&args.version, &notes);
     if !args.output_file.trim().is_empty() {
-        write_notes_file(&notes, &args.output_file, &args.version)?;
+        write_notes_file(&artifact.notes, &args.output_file, &args.version)?;
     }
     if !args.output_text_file.trim().is_empty() {
-        write_notes_file(
-            &markdown_to_plaintext(&notes),
-            &args.output_text_file,
-            &args.version,
-        )?;
+        write_notes_file(&artifact.plaintext, &args.output_text_file, &args.version)?;
     }
     if !args.output_html_file.trim().is_empty() {
-        write_notes_file(
-            &markdown_to_html_fragment(&notes),
-            &args.output_html_file,
-            &args.version,
-        )?;
+        write_notes_file(&artifact.html, &args.output_html_file, &args.version)?;
     }
     if !args.output_json.trim().is_empty() {
-        append_json_entry(&args.output_json, &args.version, &notes)?;
+        append_json_entry(&args.output_json, &artifact)?;
     }
-    print!("{}", notes);
+    print!("{}", artifact.notes);
     Ok(())
 }
 
@@ -1001,25 +1197,63 @@ fn write_notes_file(content: &str, template: &str, version: &str) -> Result<Path
     Ok(path)
 }
 
-fn append_json_entry(template: &str, version: &str, notes: &str) -> Result<()> {
-    let path = PathBuf::from(template.replace("{version}", version));
+fn append_json_entry(template: &str, artifact: &ReleaseNoteArtifact) -> Result<()> {
+    let path = PathBuf::from(template.replace("{version}", &artifact.tag));
     let mut entries = if path.is_file() {
         serde_json::from_str::<Vec<Value>>(&fs::read_to_string(&path)?)?
     } else {
         Vec::new()
     };
-    entries.retain(|entry| entry["version"].as_str() != Some(version));
-    entries.push(json!({
-        "version": version.trim_start_matches('v'),
-        "tag": version,
-        "notes": notes,
-        "html": markdown_to_html_fragment(notes),
-        "plaintext": markdown_to_plaintext(notes),
-        "published_at": Utc::now().to_rfc3339(),
-    }));
+    entries.retain(|entry| {
+        entry["tag"].as_str() != Some(&artifact.tag)
+            && entry["version"].as_str() != Some(&artifact.version)
+    });
+    entries.push(artifact.json_entry());
     ensure_parent(&path)?;
     fs::write(path, serde_json::to_string_pretty(&entries)? + "\n")?;
     Ok(())
+}
+
+fn parse_note_sections(markdown: &str) -> Vec<NoteSection> {
+    let mut sections = Vec::new();
+    let mut current = NoteSection {
+        title: "Release notes".to_string(),
+        bullets: Vec::new(),
+    };
+    let link_re = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)").unwrap();
+    for line in markdown.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("## ") {
+            if !current.bullets.is_empty() || current.title != "Release notes" {
+                sections.push(current);
+            }
+            current = NoteSection {
+                title: trimmed.trim_start_matches('#').trim().to_string(),
+                bullets: Vec::new(),
+            };
+            continue;
+        }
+        if let Some(text) = trimmed.strip_prefix("- ") {
+            let links = link_re
+                .captures_iter(text)
+                .filter_map(|caps| {
+                    let href = caps.get(2)?.as_str();
+                    Some(NoteLink {
+                        label: caps.get(1)?.as_str().to_string(),
+                        href: safe_link_href(href)?.to_string(),
+                    })
+                })
+                .collect();
+            current.bullets.push(NoteBullet {
+                text: markdown_to_plaintext(text),
+                links,
+            });
+        }
+    }
+    if !current.bullets.is_empty() || current.title != "Release notes" {
+        sections.push(current);
+    }
+    sections
 }
 
 fn markdown_to_plaintext(markdown: &str) -> String {
@@ -1076,6 +1310,7 @@ fn update_feed(args: UpdateFeedArgs) -> Result<()> {
         return Err("max-entries must be positive".into());
     }
     let notes = read_nonempty(&args.notes_file)?;
+    let artifact = ReleaseNoteArtifact::from_markdown(&args.release_tag, &notes);
     let path = args.workspace.join(&args.feed_file);
     let canonical_workspace = args
         .workspace
@@ -1095,7 +1330,7 @@ fn update_feed(args: UpdateFeedArgs) -> Result<()> {
         title: format!("{} {}", args.repository, args.release_tag),
         link: args.release_url,
         guid: args.release_tag.clone(),
-        description: markdown_to_html_fragment(&notes),
+        description: artifact.html,
         pub_date: Utc::now().to_rfc2822(),
     };
     items.retain(|item| item.guid != new_item.guid);
@@ -1171,15 +1406,8 @@ fn notify_webhook(args: NotifyWebhookArgs) -> Result<()> {
     validate_url(&args.webhook_url)?;
     validate_repo(&args.repository)?;
     let notes = read_nonempty(&args.notes_file)?;
-    let payload = json!({
-        "version": args.version,
-        "repository": args.repository,
-        "release_url": args.release_url,
-        "notes": notes,
-        "html": markdown_to_html_fragment(&notes),
-        "plaintext": markdown_to_plaintext(&notes),
-        "published_at": Utc::now().to_rfc3339(),
-    });
+    let artifact = ReleaseNoteArtifact::from_markdown(&args.version, &notes);
+    let payload = artifact.webhook_payload(&args.repository, &args.release_url);
     let body = payload.to_string();
     let mut command = Command::new("curl");
     command
@@ -1224,13 +1452,8 @@ fn notify_slack(args: NotifySlackArgs) -> Result<()> {
     }
     validate_repo(&args.repository)?;
     let notes = read_nonempty(&args.notes_file)?;
-    let payload = json!({
-        "blocks": [
-            {"type": "header", "text": {"type": "plain_text", "text": format!("{} {}", args.repository, args.version)}},
-            {"type": "section", "text": {"type": "mrkdwn", "text": markdown_to_slack(&notes)}},
-            {"type": "context", "elements": [{"type": "mrkdwn", "text": format!("<{}|View release>", args.release_url)}]}
-        ]
-    });
+    let artifact = ReleaseNoteArtifact::from_markdown(&args.version, &notes);
+    let payload = artifact.slack_payload(&args.repository, &args.release_url);
     let response = curl_json("POST", &args.slack_webhook_url, None, Some(&payload))?;
     if (200..300).contains(&response.status) {
         Ok(())
@@ -1240,9 +1463,17 @@ fn notify_slack(args: NotifySlackArgs) -> Result<()> {
 }
 
 fn markdown_to_slack(markdown: &str) -> String {
-    let text = Regex::new(r"\[([^\]]+)\]\((https?://[^)]+)\)")
+    let text = Regex::new(r"\[([^\]]+)\]\(([^)]+)\)")
         .unwrap()
-        .replace_all(markdown, "<$2|$1>")
+        .replace_all(markdown, |caps: &regex::Captures| {
+            let label = caps.get(1).unwrap().as_str();
+            let href = caps.get(2).unwrap().as_str();
+            if safe_link_href(href).is_some() {
+                format!("<{href}|{label}>")
+            } else {
+                label.to_string()
+            }
+        })
         .to_string();
     text.replace("**", "*")
 }
@@ -2203,6 +2434,26 @@ fn read_nonempty(path: &Path) -> Result<String> {
     }
 }
 
+fn write_json_if_requested<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    if !is_requested_path(path) {
+        return Ok(());
+    }
+    ensure_parent(path)?;
+    fs::write(path, serde_json::to_string_pretty(value)? + "\n")?;
+    Ok(())
+}
+
+fn read_json_array_if_requested(path: &Path) -> Result<Vec<Value>> {
+    if !is_requested_path(path) || !path.is_file() {
+        return Ok(Vec::new());
+    }
+    Ok(serde_json::from_str(&fs::read_to_string(path)?)?)
+}
+
+fn is_requested_path(path: &Path) -> bool {
+    !path.as_os_str().is_empty() && path != Path::new(".")
+}
+
 fn validate_nonblank(value: &str, name: &str) -> Result<()> {
     if value.trim().is_empty() {
         Err(format!("{name} must not be blank").into())
@@ -2265,6 +2516,70 @@ mod tests {
             markdown_to_html_fragment("[bad](javascript:alert(1)) [ok](https://example.com)");
         assert!(html.contains("href=\"#\""));
         assert!(html.contains("href=\"https://example.com\""));
+    }
+
+    #[test]
+    fn typed_artifact_renders_shared_outputs() {
+        let artifact = ReleaseNoteArtifact::from_markdown(
+            "v1.2.3",
+            "## Added\n\n- See [docs](https://example.com) and [bad](javascript:alert(1))",
+        );
+        assert_eq!(artifact.version, "1.2.3");
+        assert!(artifact.html.contains("href=\"https://example.com\""));
+        assert!(artifact.html.contains("href=\"#\""));
+        assert!(artifact.plaintext.contains("See docs and bad"));
+        assert!(artifact.slack.contains("<https://example.com|docs>"));
+        assert!(!artifact.slack.contains("javascript:"));
+        assert_eq!(artifact.sections[0].title, "Added");
+        assert_eq!(
+            artifact.sections[0].bullets[0].links[0].href,
+            "https://example.com"
+        );
+        assert!(artifact.json_entry()["sections"].is_array());
+    }
+
+    #[test]
+    fn summary_status_includes_attempts_and_destinations() {
+        let output = temp_file("summary-test").unwrap();
+        let attempts = temp_file("attempts-test").unwrap();
+        fs::write(
+            &attempts,
+            r#"[{"model":"primary","succeeded":false},{"model":"fallback","succeeded":true}]"#,
+        )
+        .unwrap();
+        let args = SummaryArgs {
+            synthesis_enabled: "true".into(),
+            released: "true".into(),
+            synth_succeeded: "true".into(),
+            synth_quality: "valid".into(),
+            update_succeeded: "true".into(),
+            synth_failure_stage: "".into(),
+            synth_failure_message: "".into(),
+            update_failure_stage: "".into(),
+            update_failure_message: "".into(),
+            artifact_succeeded: "true".into(),
+            artifact_failure_stage: "".into(),
+            artifact_failure_message: "".into(),
+            rss_enabled: "true".into(),
+            rss_succeeded: "false".into(),
+            rss_failure_stage: "rss_update".into(),
+            rss_failure_message: "push failed".into(),
+            webhook_enabled: "true".into(),
+            webhook_sent: "true".into(),
+            slack_enabled: "true".into(),
+            slack_sent: "false".into(),
+            github_output: output.clone(),
+            attempts_file: attempts,
+        };
+        summary_policy(args).unwrap();
+        let outputs = parse_outputs(&output).unwrap();
+        assert_eq!(outputs["succeeded"], "false");
+        let status: Value = serde_json::from_str(&outputs["status_json"]).unwrap();
+        assert_eq!(status["model_attempts"].as_array().unwrap().len(), 2);
+        assert_eq!(status["destinations"]["rss"]["enabled"], true);
+        assert_eq!(status["destinations"]["rss"]["failure_stage"], "rss_update");
+        assert_eq!(status["destinations"]["webhook"]["succeeded"], true);
+        assert_eq!(status["destinations"]["slack"]["succeeded"], false);
     }
 
     #[test]

--- a/dist/landfall.sha256
+++ b/dist/landfall.sha256
@@ -1,1 +1,1 @@
-b21ffeaf83a2d6e9390d1efab007bcecb9da439988d186d6b6a9fbad6c1cdb90  dist/landfall
+6a3c3cbd99f2b41586d36b933405d8460e6f91a99ff9e07c6600ed4ecee86ae1  dist/landfall


### PR DESCRIPTION
## Summary
- adds a shared Rust `ReleaseNoteArtifact` model for markdown, plaintext, HTML, Slack, RSS, webhook JSON, stored JSON, and section/bullet/link data
- adds machine-readable `synthesis-status` output with quality, failure stage/message, model attempts, and release body/artifact/RSS/webhook/Slack destinations
- adds `synthesis-failure-issue-action` as the explicit companion output channel for failure issue close/report/failure/skipped states
- preserves existing scalar outputs and JSON-feed compatibility, including dedupe by both `tag` and older `version` entries

## Verification
- `bin/gate`
- `cargo test --locked` (6 tests, including typed artifact rendering and status JSON coverage)
- `shasum -a 256 -c dist/landfall.sha256`
- Grok adversarial review: NO BLOCKERS
- Claude QA lane: PASS
- focused post-review Grok check: NO BLOCKERS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `synthesis-status` output providing synthesis quality metrics and model attempt details
  * Added `synthesis-failure-issue-action` output reporting synthesis failure issue lifecycle outcomes
  * Enriched release-notes JSON artifact schema with multiple format variants (markdown, plaintext, HTML, Slack), structured sections with bullets and links, and publication timestamps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->