### PR TITLE
chore(release): 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# [1.18.0](https://github.com/misty-step/landfall/compare/v1.17.2...v1.18.0) (2026-06-12)
+
+### Features
+
+* **runtime:** migrate owned Landfall runtime to Rust (#109) ([3ad9dcb](https://github.com/misty-step/landfall/commit/3ad9dcb25783053a5c7f56c7c2c4c6cf0c2357b8))
+* **notes:** add typed release note artifact plane (#110) ([58c814a](https://github.com/misty-step/landfall/commit/58c814a5db4f7f341097d57c75ada11199878eb8))
+* **setup:** add adoption analyzer and workflow generator (#111) ([2e30c8d](https://github.com/misty-step/landfall/commit/2e30c8dd7da47aae5f8694c2ebad75534cd35741))
+* **release:** add pr-based self-release flow (#112) ([81e9711](https://github.com/misty-step/landfall/commit/81e9711c89fe6e0e1bb683778ddc2299707d846e))
+
+### Bug Fixes
+
+* **healthcheck:** auto-run when synthesis enabled, add OpenRouter-specific 401 message (#99) ([9a1e4c9](https://github.com/misty-step/landfall/commit/9a1e4c9165661e6aa2e6b4a8fe1c645b4fa34879))
+* **ci:** avoid duplicate trufflehog fail flag (#106) ([12441ec](https://github.com/misty-step/landfall/commit/12441ec32afb35156e1c00eb62a3c32514919b8d))
+* **ci:** allow release candidate metadata checks (#114) ([f645ea0](https://github.com/misty-step/landfall/commit/f645ea0e36eeb544ff24da40600b36f21618b7a2))
 ## [1.17.2](https://github.com/misty-step/landfall/compare/v1.17.1...v1.17.2) (2026-02-13)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "landfall"
-version = "1.17.2"
+version = "1.18.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/landfall/Cargo.toml
+++ b/crates/landfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "landfall"
-version = "1.17.2"
+version = "1.18.0"
 edition = "2024"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -1,9 +1,4 @@
 {
-  "name": "landfall",
-  "version": "1.17.2",
-  "private": true,
-  "description": "Focused release pipeline action powered by semantic-release.",
-  "license": "MIT",
   "dependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^11.1.0",
@@ -12,5 +7,10 @@
     "@semantic-release/github": "^10.3.5",
     "@semantic-release/release-notes-generator": "^12.1.0",
     "semantic-release": "^24.2.0"
-  }
+  },
+  "description": "Focused release pipeline action powered by semantic-release.",
+  "license": "MIT",
+  "name": "landfall",
+  "private": true,
+  "version": "1.18.0"
 }


### PR DESCRIPTION
Automated Landfall self-release PR.

- Release tag: `v1.18.0`
- Generated files: `CHANGELOG.md`, `package.json`, `crates/landfall/Cargo.toml`, `Cargo.lock`
- Required pre-merge check: `merge-gate`

The GitHub Release is published only after this PR lands on protected `master`.