### PR TITLE
chore(release): 1.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [1.18.1](https://github.com/misty-step/landfall/compare/v1.18.0...v1.18.1) (2026-06-12)
+
+### Bug Fixes
+
+* **release:** stabilize self-release post-publish gates ([3bb2bdd](https://github.com/misty-step/landfall/commit/3bb2bddf45c3babca63607fb662e7bba497a6bd2))
 # [1.18.0](https://github.com/misty-step/landfall/compare/v1.17.2...v1.18.0) (2026-06-12)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "landfall"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/landfall/Cargo.toml
+++ b/crates/landfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "landfall"
-version = "1.18.0"
+version = "1.18.1"
 edition = "2024"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -12,5 +12,5 @@
   "license": "MIT",
   "name": "landfall",
   "private": true,
-  "version": "1.18.0"
+  "version": "1.18.1"
 }


### PR DESCRIPTION
Automated Landfall self-release PR.

- Release tag: `v1.18.1`
- Generated files: `CHANGELOG.md`, `package.json`, `crates/landfall/Cargo.toml`, `Cargo.lock`
- Required pre-merge check: `merge-gate`

The GitHub Release is published only after this PR lands on protected `master`.