### PR TITLE
chore(release): 1.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [1.18.2](https://github.com/misty-step/landfall/compare/v1.18.1...v1.18.2) (2026-06-12)
+
+### Bug Fixes
+
+* **release:** keep self-release binary in sync ([1832326](https://github.com/misty-step/landfall/commit/18323261d0f2631e6ff493196240f72e17117b07))
 # [1.18.1](https://github.com/misty-step/landfall/compare/v1.18.0...v1.18.1) (2026-06-12)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "landfall"
-version = "1.18.1"
+version = "1.18.2"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/landfall/Cargo.toml
+++ b/crates/landfall/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "landfall"
-version = "1.18.1"
+version = "1.18.2"
 edition = "2024"
 
 [dependencies]

--- a/dist/landfall.sha256
+++ b/dist/landfall.sha256
@@ -1,1 +1,1 @@
-ff9be02556f7cd9b4a58f872c58e8a6e56d467295c622a3184fdd28929fd8f4c  dist/landfall
+cabc38a37ae7f7dca2a40eeb2f9550fa0b74490b07df7b1447f1fb33afc9dcb3  dist/landfall

--- a/package.json
+++ b/package.json
@@ -12,5 +12,5 @@
   "license": "MIT",
   "name": "landfall",
   "private": true,
-  "version": "1.18.1"
+  "version": "1.18.2"
 }


### PR DESCRIPTION
Automated Landfall self-release PR.

- Release tag: `v1.18.2`
- Generated files: `CHANGELOG.md`, `package.json`, `crates/landfall/Cargo.toml`, `Cargo.lock`, `dist/landfall`, `dist/landfall.sha256`
- Required pre-merge check: `merge-gate`

The GitHub Release is published only after this PR lands on protected `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with self-release binary synchronization to ensure consistency across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->