### PR TITLE
docs: add Landmark aesthetic follow-up

### DIFF
--- a/backlog.d/001-adopt-misty-step-comic-ops-aesthetic.md
+++ b/backlog.d/001-adopt-misty-step-comic-ops-aesthetic.md
@@ -1,0 +1,22 @@
+# Adopt the Misty Step comic-ops aesthetic baseline
+
+Priority: P2 · Status: pending · Estimate: M
+
+## Goal
+Evaluate and adopt the operator-pulp comic-ops flavor for Landmark release-kit,
+changelog, feed, and evidence-preview surfaces.
+
+## Oracle
+- [ ] `DESIGN.md` or project docs name the chosen flavor, likely
+      `operator-pulp`, and the artifacts it governs.
+- [ ] A representative release-kit preview is rendered or mocked with version
+      decision panels, artifact ledgers, proof strips, and hard frames.
+- [ ] Aesthetic changes do not make release evidence less portable or less
+      readable in plain Markdown/HTML/RSS outputs.
+- [ ] The implementation uses `@misty-step/aesthetic` commit `9bbe0f9` or later,
+      or records a deliberate no-adoption decision.
+- [ ] `bin/gate` passes after implementation.
+
+## Notes
+Reference board:
+`http://serenity.tail5f5eb4.ts.net:8788/landmark-operator-pulp-concept.png`.


### PR DESCRIPTION
## Summary
- Add the vision-pass backlog note for evaluating Misty Step comic-ops release surfaces.

## Verification
- docs-only backlog addition
- branch push completed