### PR TITLE
chore(release): 1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [1.26.0](https://github.com/misty-step/landmark/compare/v1.25.0...v1.26.0) (2026-07-02)
+
+### Features
+
+* **classification:** use structured release signals ([a5ab124](https://github.com/misty-step/landmark/commit/a5ab124d547819d7dba14af5a0ce6a2618272957))
+* **classification:** call model classifier before synthesis ([332c6d1](https://github.com/misty-step/landmark/commit/332c6d1c289cafe88d5d6466016575340c5e6b6a))
+* **classification:** surface model disagreement in notes ([baff359](https://github.com/misty-step/landmark/commit/baff3599a2b6fd1c6ed79add936cb8bd4563e964))
+* **release:** publish per-target binaries, bootstrap action via download (#168) ([6647390](https://github.com/misty-step/landmark/commit/6647390a55b79fc5de3a01551528060a9d7d872b))
 # [1.25.0](https://github.com/misty-step/landmark/compare/v1.24.0...v1.25.0) (2026-06-25)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "landmark"
-version = "1.25.0"
+version = "1.26.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/landmark/Cargo.toml
+++ b/crates/landmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "landmark"
-version = "1.25.0"
+version = "1.26.0"
 edition = "2024"
 
 [dependencies]

--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
   "license": "MIT",
   "name": "landmark",
   "private": true,
-  "version": "1.25.0"
+  "version": "1.26.0"
 }


### PR DESCRIPTION
Automated Landmark self-release PR.

- Release tag: `v1.26.0`
- Generated files: `CHANGELOG.md`, `package.json`, `crates/landmark/Cargo.toml`, `Cargo.lock`
- Required pre-merge checks: `merge-gate`, `trufflehog`
- Per-target release binaries and checksums are built and attached to the
  GitHub Release after this PR lands; they are not part of this diff.

The GitHub Release is published only after this PR lands on protected `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer release notes with structured update signals and clearer handling when classification results differ.
  * Introduced support for publishing per-target binaries and bootstrapping installs via download.
  * Updated versioning to **v1.26.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->