### PR TITLE
test(classification): cover misfire regression corpus

### DIFF
--- a/crates/landmark/src/classification_tests.rs
+++ b/crates/landmark/src/classification_tests.rs
@@ -203,6 +203,146 @@ fn release_notes_include_classification_notice_for_disagreements() {
     assert!(rendered.contains("deterministic floor found user-visible"));
 }
 
+#[test]
+fn classifier_keeps_workflow_manifest_cli_substrings_low_for_chore() {
+    let deterministic = deterministic_context(
+        vec![context_commit(
+            "chore(ci): refresh workflow",
+            "Touches manifest defaults and CLI examples.",
+        )],
+        vec![
+            ".github/workflows/release.yml".into(),
+            ".landmark.yml".into(),
+        ],
+    );
+    let technical = "### Chores\n\n* refresh workflow for CLI manifest setup\n".to_string();
+    let sources = vec![context_source(
+        "technical_changelog",
+        "changelog",
+        &technical,
+    )];
+
+    let classification =
+        classify_release_context_with_deterministic(&technical, &sources, &deterministic);
+
+    assert!(!classification.user_visible, "{classification:?}");
+    assert_eq!(classification.significance, "low");
+    assert!(
+        classification
+            .deterministic_signals
+            .iter()
+            .any(|signal| signal == "conventional:chore"),
+        "{classification:?}"
+    );
+    assert!(
+        classification
+            .categories
+            .iter()
+            .any(|category| category == "internal-tooling"),
+        "{classification:?}"
+    );
+}
+
+#[test]
+fn classifier_recovers_conventional_floor_from_squash_body() {
+    let deterministic = deterministic_context(
+        vec![context_commit(
+            "Merge pull request #42 from feature/import",
+            "- feat(cli): add import wizard\n- fix(parser): handle CSV rows",
+        )],
+        vec!["src/import.rs".into(), "src/parser.rs".into()],
+    );
+    let technical =
+        "### Features\n\n* add import wizard\n\n### Bug Fixes\n\n* handle CSV rows\n".to_string();
+    let sources = vec![context_source(
+        "technical_changelog",
+        "changelog",
+        &technical,
+    )];
+
+    let classification =
+        classify_release_context_with_deterministic(&technical, &sources, &deterministic);
+
+    assert!(classification.user_visible, "{classification:?}");
+    assert_eq!(classification.significance, "medium");
+    assert!(
+        classification
+            .deterministic_signals
+            .iter()
+            .any(|signal| signal == "conventional:feat"),
+        "{classification:?}"
+    );
+    assert!(
+        classification
+            .deterministic_signals
+            .iter()
+            .any(|signal| signal == "conventional:fix"),
+        "{classification:?}"
+    );
+}
+
+#[test]
+fn classifier_treats_perf_as_user_visible_floor_signal() {
+    let deterministic = deterministic_context(
+        vec![context_commit(
+            "perf(api): cache release lookup",
+            "Speeds up repeated release scans.",
+        )],
+        vec!["src/cache.rs".into()],
+    );
+    let technical = "### Performance\n\n* cache release lookup\n".to_string();
+    let sources = vec![context_source(
+        "technical_changelog",
+        "changelog",
+        &technical,
+    )];
+
+    let classification =
+        classify_release_context_with_deterministic(&technical, &sources, &deterministic);
+
+    assert!(classification.user_visible, "{classification:?}");
+    assert!(
+        classification
+            .deterministic_signals
+            .iter()
+            .any(|signal| signal == "conventional:perf"),
+        "{classification:?}"
+    );
+}
+
+#[test]
+fn classifier_handles_empty_context_without_panicking() {
+    let classification = classify_release_context_with_deterministic(
+        "",
+        &[],
+        &DeterministicReleaseContext::default(),
+    );
+
+    assert!(classification.user_visible, "{classification:?}");
+    assert_eq!(classification.significance, "medium");
+}
+
+fn deterministic_context(
+    commits: Vec<ContextCommit>,
+    changed_files: Vec<String>,
+) -> DeterministicReleaseContext {
+    DeterministicReleaseContext {
+        commits,
+        changed_files,
+        ..Default::default()
+    }
+}
+
+fn context_commit(subject: &str, body: &str) -> ContextCommit {
+    ContextCommit {
+        subject: subject.into(),
+        body: body.into(),
+        short_hash: "abc1234".into(),
+        conventional_type: conventional_commit_type(subject).unwrap_or("").into(),
+        breaking: body.contains("BREAKING CHANGE:"),
+    }
+}
+
 fn test_synthesis_config(model_policy: &str) -> EffectiveSynthesisConfig {
     EffectiveSynthesisConfig {
         product_name: "Demo".into(),

--- a/crates/landmark/src/release_classification.rs
+++ b/crates/landmark/src/release_classification.rs
@@ -29,24 +29,26 @@ pub(crate) fn classify_release_context_with_deterministic(
 
     for commit in &relevant_commits {
         let commit_text = format!("{}\n{}", commit.subject, commit.body).to_ascii_lowercase();
-        match commit.conventional_type.as_str() {
-            "feat" | "fix" | "perf" => {
-                user_visible = true;
-                categories.insert("user-visible");
-                deterministic_signals.insert(format!("conventional:{}", commit.conventional_type));
+        for commit_type in commit_conventional_types(commit) {
+            match commit_type.as_str() {
+                "feat" | "fix" | "perf" => {
+                    user_visible = true;
+                    categories.insert("user-visible");
+                    deterministic_signals.insert(format!("conventional:{commit_type}"));
+                }
+                "docs" => {
+                    docs_count += 1;
+                    low_value_count += 1;
+                    categories.insert("docs-only");
+                    deterministic_signals.insert("conventional:docs".to_string());
+                }
+                "chore" | "ci" | "build" | "test" | "refactor" => {
+                    low_value_count += 1;
+                    categories.insert("chore-only");
+                    deterministic_signals.insert(format!("conventional:{commit_type}"));
+                }
+                _ => {}
             }
-            "docs" => {
-                docs_count += 1;
-                low_value_count += 1;
-                categories.insert("docs-only");
-                deterministic_signals.insert("conventional:docs".to_string());
-            }
-            "chore" | "ci" | "build" | "test" | "refactor" => {
-                low_value_count += 1;
-                categories.insert("chore-only");
-                deterministic_signals.insert(format!("conventional:{}", commit.conventional_type));
-            }
-            _ => {}
         }
         if commit.breaking {
             breaking = true;
@@ -451,6 +453,19 @@ pub(crate) fn push_unique_category(categories: &mut Vec<String>, category: &str)
     }
 }
 
+pub(crate) fn commit_conventional_types(commit: &ContextCommit) -> BTreeSet<String> {
+    let mut types = BTreeSet::new();
+    if !commit.conventional_type.trim().is_empty() {
+        types.insert(commit.conventional_type.clone());
+    }
+    for line in commit.body.lines() {
+        if let Some(commit_type) = conventional_commit_type(normalized_commit_line(line)) {
+            types.insert(commit_type.to_string());
+        }
+    }
+    types
+}
+
 pub(crate) fn release_relevant_commits<'a>(
     technical: &str,
     deterministic: &'a DeterministicReleaseContext,
@@ -467,10 +482,31 @@ pub(crate) fn release_relevant_commits<'a>(
 }
 
 pub(crate) fn commit_matches_release_text(commit: &ContextCommit, lower_technical: &str) -> bool {
-    let subject = commit.subject.to_ascii_lowercase();
-    lower_technical.contains(&subject)
-        || commit_summary(&subject)
-            .is_some_and(|summary| !summary.is_empty() && lower_technical.contains(summary))
+    commit_candidate_lines(commit).into_iter().any(|line| {
+        let line = line.to_ascii_lowercase();
+        lower_technical.contains(&line)
+            || commit_summary(&line)
+                .is_some_and(|summary| !summary.is_empty() && lower_technical.contains(summary))
+    })
+}
+
+pub(crate) fn commit_candidate_lines(commit: &ContextCommit) -> Vec<&str> {
+    let mut lines = vec![commit.subject.as_str()];
+    lines.extend(
+        commit
+            .body
+            .lines()
+            .map(normalized_commit_line)
+            .filter(|line| conventional_commit_type(line).is_some()),
+    );
+    lines
+}
+
+pub(crate) fn normalized_commit_line(line: &str) -> &str {
+    line.trim()
+        .trim_start_matches("- ")
+        .trim_start_matches("* ")
+        .trim()
 }
 
 pub(crate) fn commit_summary(subject: &str) -> Option<&str> {

--- a/dist/landmark.sha256
+++ b/dist/landmark.sha256
@@ -1,1 +1,1 @@
-96eb7e668e4807eb70bf7a6b595976839bc7de8409962a061c8cb0fc1eafde2e  dist/landmark
+b8b51aa1c83df9982547a702e7376bd33fad978514f41d5bec4fc1c5a6aab51d  dist/landmark


### PR DESCRIPTION
## Summary\n- recover conventional floor signals from squash commit bodies\n- add regression coverage for workflow/manifest/CLI substring landmines, squash body feat/fix lines, perf commits, and empty context behavior\n\n## Verification\n- cargo test --locked -p landmark classification_tests -- --nocapture\n- bin/gate\n- fresh Pi critic: no blocking gaps\n\nAgent: codex\nAgent-Surface: Codex CLI\nAgent-Task: backlog/003-model-native-classification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release classification so conventional commit signals can be detected from both commit subjects and relevant body text.
  * Better handles squash-merge style messages, helping feature and fix changes be recognized more accurately.
  * `perf` changes are now treated as user-visible, and empty inputs no longer cause crashes during classification.
  * Reduced false positives for chore-style changes when technical CLI terms appear in commit context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->