### PR TITLE
docs(synthesis): stop forcing every bullet to open the same way

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,7 +851,7 @@ Synthesized `## What's New` section (prepended):
 ## What's New
 
 ## New Features
-- You can now import workspace configuration in one command, reducing setup time.
+- Import workspace configuration in one command, cutting setup time.
 
 ## Bug Fixes
 - Webhook deliveries now retry more reliably when signatures expire.

--- a/templates/prompts/developer.md
+++ b/templates/prompts/developer.md
@@ -12,9 +12,12 @@ Transform the technical changelog below into concise notes for engineers integra
 
 - Breaking changes: If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, why, migration steps. Do not repeat them in other sections.
 - Prioritize integration impact: API behavior, configuration changes, migration implications, and reliability fixes.
-- For new capabilities, start bullets with "You can now...".
-- For fixes, start bullets with "Fixed...".
-- For improvements, start bullets with "The [thing] now...".
+- For new capabilities, lead with the integration-relevant benefit.
+- For fixes, state plainly what was broken and that it's fixed.
+- For improvements, show what got better.
+- Vary how bullets open. Do not start every feature bullet with "You can now," every fix
+  with "Fixed," or every improvement with "The [thing] now" — that repetition reads as
+  templated. Let each bullet's specific content dictate its own natural phrasing.
 - Include practical impact and required action when relevant (for example, update config, rotate key, rerun migration).
 - Omit purely internal items unless they directly affect users or integrators.
 - Never include PR numbers, commit hashes, issue IDs, file paths, or internal process details.

--- a/templates/prompts/end-user.md
+++ b/templates/prompts/end-user.md
@@ -13,9 +13,12 @@ Transform the technical changelog below into simple, benefit-first updates for n
 - Breaking changes: If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, what to do next.
 - Use plain language and avoid jargon.
 - Focus on user outcomes: speed, reliability, clarity, ease of use, and reduced friction.
-- For new capabilities, start bullets with "You can now...".
-- For fixes, start bullets with "Fixed...".
-- For improvements, start bullets with "The [thing] now...".
+- For new capabilities, lead with the benefit from the user's perspective.
+- For fixes, state plainly what was broken and that it's fixed.
+- For improvements, show what got better.
+- Vary how bullets open. Do not start every feature bullet with "You can now," every fix
+  with "Fixed," or every improvement with "The [thing] now" — that repetition reads as
+  templated. Let each bullet's specific content dictate its own natural phrasing.
 - Keep each non-breaking bullet to one short sentence.
 - Omit internal-only changes unless they clearly improve user experience.
 - Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.

--- a/templates/prompts/enterprise.md
+++ b/templates/prompts/enterprise.md
@@ -14,9 +14,12 @@ Transform the technical changelog below into updates for security, compliance, a
 - Prioritize security and risk impact first, then reliability and platform updates.
 - Preserve CVE identifiers exactly when present (for example, `CVE-2024-1234`).
 - Explicitly call out compliance-relevant changes when mentioned (auditability, access control, encryption, retention).
-- For new capabilities, start bullets with "You can now...".
-- For fixes, start bullets with "Fixed...".
-- For improvements, start bullets with "The [thing] now...".
+- For new capabilities, lead with the operational or compliance-relevant benefit.
+- For fixes, state plainly what was broken and that it's fixed.
+- For improvements, show what got better.
+- Vary how bullets open. Do not start every feature bullet with "You can now," every fix
+  with "Fixed," or every improvement with "The [thing] now" — that repetition reads as
+  templated. Let each bullet's specific content dictate its own natural phrasing.
 - Include required follow-up actions when relevant (rotation, policy update, migration step).
 - Omit internal-only items unless they affect security posture, compliance, or operations.
 - Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.

--- a/templates/prompts/general.md
+++ b/templates/prompts/general.md
@@ -11,9 +11,12 @@ Transform the technical changelog below into user-facing release notes.
 ## Writing guidelines
 
 - **Breaking changes:** If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, why, migration steps. Do not repeat them in other sections.
-- **Features:** Start with "You can now..." to frame new capabilities from the user's perspective.
-- **Bug fixes:** Start with "Fixed..." to confirm resolution clearly.
-- **Improvements:** Start with "The [thing] now..." to show what got better.
+- **Features:** Frame new capabilities from the user's perspective and lead with the benefit.
+- **Bug fixes:** State plainly what was broken and that it's fixed.
+- **Improvements:** Show what got better and by how much, when the changelog says.
+- Vary how bullets open. Do not start every feature bullet with "You can now," every fix
+  with "Fixed," or every improvement with "The [thing] now" — that repetition reads as
+  templated. Let each bullet's specific content dictate its own natural phrasing.
 - Each non-breaking bullet should be one concise sentence explaining what changed and why it matters.
 - Omit internal-only items (CI, tooling, refactors, dependency bumps) unless they have user-visible impact.
 - Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.

--- a/templates/synthesis-prompt.md
+++ b/templates/synthesis-prompt.md
@@ -11,9 +11,13 @@ Transform the technical changelog below into user-facing release notes.
 ## Writing guidelines
 
 - **Breaking changes:** If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, why, migration steps. Do not repeat them in other sections.
-- **Features:** Start with "You can now..." to frame new capabilities from the user's perspective.
-- **Bug fixes:** Start with "Fixed..." to confirm resolution clearly.
-- **Improvements:** Start with "The [thing] now..." to show what got better.
+- **Features:** Frame new capabilities from the user's perspective and lead with the benefit.
+- **Bug fixes:** State plainly what was broken and that it's fixed.
+- **Improvements:** Show what got better and by how much, when the changelog says.
+- Vary how bullets open. Do not start every feature bullet with "You can now," every fix
+  with "Fixed," or every improvement with "The [thing] now" — that repetition reads as
+  templated. Let each bullet's specific content dictate its own natural phrasing (see the
+  examples below for the range of openings expected).
 - Each non-breaking bullet should be one concise sentence explaining what changed and why it matters.
 - Omit internal-only items (CI, tooling, refactors, dependency bumps) unless they have user-visible impact.
 - Never include PR numbers, commit hashes, issue IDs, file paths, function names, or internal process details.
@@ -47,11 +51,11 @@ Technical changelog:
 
 Expected release notes:
 ## New Features
-- You can now import workspace configuration in one click, reducing initial setup time.
-- You can now customize theme colors from the settings page.
+- Import workspace configuration in one click, cutting initial setup time.
+- Theme colors are now customizable from the settings page.
 
 ## Bug Fixes
-- Fixed webhook deliveries failing silently when signatures expired.
+- Webhook deliveries no longer fail silently when signatures expire; they retry instead.
 
 ### Example 2: Patch release
 
@@ -63,7 +67,7 @@ Technical changelog:
 
 Expected release notes:
 ## Bug Fixes
-- Fixed a dashboard crash that occurred when saving a profile with empty fields.
+- Saving a profile with empty fields no longer crashes the dashboard.
 
 ### Example 3: Breaking change
 
@@ -78,7 +82,7 @@ Expected release notes:
 - The deprecated `/v1/auth` endpoint was removed to simplify the authentication surface area. If you were using it, migrate to the new OAuth 2.0 PKCE flow before upgrading.
 
 ## New Features
-- You can now authenticate using OAuth 2.0 with PKCE for a more secure sign-in flow.
+- OAuth 2.0 with PKCE is now supported for a more secure sign-in flow.
 
 ---
 


### PR DESCRIPTION
## Summary
The groom report's output-quality audit flagged it directly: every synthesized release note in the fleet starts feature bullets with "You can now...", fixes with "Fixed...", and improvements with "The [thing] now..." — because all four audience prompt templates (`developer.md`, `end-user.md`, `enterprise.md`, `general.md`) literally instructed the model to. Content was real and technically accurate; voice was a metronome, and it was on track to become the new template slop.

Replaces the rigid "start with X" instruction in each template with guidance to lead with the same information (benefit for features, plain resolution for fixes, improvement for improvements) while varying how each bullet opens across a release.

Part of backlog 008 ("Build fleet self-healing upgrades"), child 4, taken as its own small independent slice rather than waiting on the larger drift-detection/upgrade-PR machinery in that ticket.

## Test plan
- [x] `cargo test --locked` (65 tests), `check-action-contract`, `replay-action` (24 scenarios) all pass — nothing in the runtime asserts the literal template wording, confirmed via grep
- [x] No live doc/contract quotes the old "You can now" instruction text verbatim (checked README.md, docs/agent-integration.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)