### PR TITLE
chore(backlog): import overnight refill tickets

### DIFF
--- a/backlog.d/011-fix-release-kit-classifier-call-site.md
+++ b/backlog.d/011-fix-release-kit-classifier-call-site.md
@@ -1,0 +1,52 @@
+# Fix release_kit::plan's classifier call site to use structured commit data
+
+Priority: P0 · Status: ready · Estimate: M
+
+## Goal
+`release_kit::plan` (`crates/landmark/src/release_kit.rs:173`) still calls the
+plain-text substring classifier (`classify_release_context`, the
+`classify_release_context_from_text` path) instead of the structured,
+model-native classifier (`classify_release_context_with_deterministic` /
+`classify_release_context_with_model`) that `synthesis.rs` already switched to.
+Fix the call site so release-kit importance/audience planning is driven by
+parsed commit data, closing the same misfire class the classifier fix already
+closed for synthesis.
+
+## Oracle
+- [ ] `release_kit::plan` builds a `DeterministicReleaseContext`/`Vec<ContextCommit>`
+      from `release.commits` (using the existing `classify_commit` parser for
+      `conventional_type`/`breaking`, mirroring how `synthesis.rs` builds its
+      deterministic context) and passes it to
+      `classify_release_context_with_deterministic` (or `_with_model` where a
+      model is configured), not the bare-text `classify_release_context`.
+- [ ] A regression test reproduces the exact landmark v1.25.0 shape already
+      pinned in `crates/landmark/src/classification_tests.rs` (commits:
+      `feat(fleet): deliver backfill-first adoption lane`,
+      `feat(run): emit release kit artifact graph`,
+      `fix(fleet): attach to existing release workflows`, rendered as
+      `### Features` / `### Bug Fixes` semantic-release headers) but exercised
+      through `release_kit::plan`, and asserts `importance` is NOT `"low"` and
+      `release_kit_needs_rich_artifacts` behaves accordingly.
+- [ ] `cargo test --locked` and `bin/gate` pass.
+
+## Notes
+Verified live in `crates/landmark/src/release_kit.rs:150-174`: `release.commits`
+(type `Vec<RunCommit>` with `subject`/`short_hash`/`body`,
+`crates/landmark/src/release_ops/models.rs:252`) is already available at the
+call site, so building the deterministic commit list is a small adapter, not a
+redesign. `release_kit_importance` (`release_kit.rs:438-456`) directly branches
+on `classification.significance`/`.security`/`.breaking`/`.migration_heavy`,
+and a "low" significance from the substring classifier's landmine bugs (e.g.
+`lower.contains("cli")` matching "reconcile", `"manifest"`/`"configuration"`
+false-escalating, or simply missing `### Features`-style semantic-release
+headers) silently shrinks the planned final-mile artifact set
+(`release_kit_needs_rich_artifacts`, `release_kit.rs:469`) for what may be an
+important release — the same failure shape as the groom teardown's headline
+finding (`.factory-lanes/groom/landmark.md` §1), just in the kit-planning path
+instead of the synthesis-skip path that was already fixed tonight (PR series
+ending in commit `f7e122e`). This ticket closes the second call site.
+
+**Why:** teardown finding §1 was fixed for `synthesis.rs` but `release_kit.rs`
+was missed — confirmed live via `grep -rn "classify_release_context(" crates/landmark/src`,
+which shows `release_kit.rs:173` is the only remaining caller of the unstructured
+text classifier outside its own definition and tests.

--- a/backlog.d/012-test-release-kit-importance-matrix.md
+++ b/backlog.d/012-test-release-kit-importance-matrix.md
@@ -1,0 +1,42 @@
+# Pin release_kit's importance/audience/rich-artifact decision matrix with unit tests
+
+Priority: P1 · Status: ready · Estimate: S
+
+## Goal
+`crates/landmark/src/release_kit.rs` (990 lines) has zero `#[test]` functions
+covering `release_kit_importance`, `release_kit_audiences`,
+`release_kit_needs_rich_artifacts`, or `release_kit_importance_reason` — the
+functions that decide which final-mile artifacts (migration guides, docs
+patches, blog drafts, demo videos) get planned for a release. Add direct unit
+tests pinning the existing decision table so it can't silently drift.
+
+## Oracle
+- [ ] `release_kit_importance` (`release_kit.rs:438-456`) has a test per
+      branch: `security` (classification.security), `migration` (major bump,
+      or classification.breaking, or migration_heavy), `high`
+      (significance == "high"), `launch` (empty latest_tag + bump != "none"),
+      `low` (significance == "low"), and the `medium` fallback — constructed
+      directly from `ReleaseClassification`/`RunVersionDecision` values, not
+      through the full `plan()` pipeline.
+- [ ] `release_kit_audiences` (`release_kit.rs:458-467`) has a test proving
+      `release-operator`/`docs-owner` are added only when
+      `release_kit_needs_rich_artifacts(importance)` is true, and the primary
+      audience plus `developer-operator` are always present.
+- [ ] `release_kit_needs_rich_artifacts` (`release_kit.rs:469`) has a test
+      naming every importance value it treats as needing rich artifacts vs not.
+- [ ] `cargo test --locked` and `bin/gate` pass.
+
+## Notes
+Verified live: `grep -rn "fn.*release_kit\|#\[test\]" crates/landmark/src/release_kit.rs`
+shows no test functions, and `cargo test --locked release_kit` runs 0 tests.
+The only existing coverage is `release_kit::assert_contract` inside replay
+scenarios, which checks JSON *shape*, not that `importance`/`audiences` are
+*correct* for a given classification/decision input. This ticket is
+independent of `011-fix-release-kit-classifier-call-site.md` — it unit-tests
+the pure decision functions directly with constructed inputs, so it can land
+before, after, or alongside 011 without conflict.
+
+**Why:** teardown report flagged release-kit as the highest-leverage untested
+surface once classification correctness is addressed; this closes the "zero
+unit tests on a 990-line decision module" gap independently confirmed by
+running `cargo test --locked release_kit` (0 tests) during this groom pass.

--- a/backlog.d/013-tighten-release-context-classification-schema.md
+++ b/backlog.d/013-tighten-release-context-classification-schema.md
@@ -1,0 +1,53 @@
+# Tighten release-context.v1.schema.json's classification/cost objects and add drift detection
+
+Priority: P1 · Status: ready · Estimate: M
+
+## Goal
+`schemas/release-context.v1.schema.json`'s `classification` and `cost`
+sub-objects are declared as bare `{ "type": "object" }` with no `properties`,
+even though the Rust structs they describe (`ReleaseClassification`,
+`CostEstimate` in `crates/landmark/src/manifest.rs:176-201`) are stable and
+richer than that today (including the newer `deterministic_signals` and
+`disagreements` fields). Add real `properties`/`required` to both, and wire a
+drift check so the schema can't silently fall out of sync with the struct
+again, following the pattern the repo already uses for the manifest schema.
+
+## Oracle
+- [ ] `schemas/release-context.v1.schema.json`'s `classification` property
+      lists `categories`, `significance`, `user_visible`, `breaking`,
+      `security`, `migration_heavy`, `source`, `model`,
+      `deterministic_signals`, `disagreements`, `reasons` with correct types.
+- [ ] `schemas/release-context.v1.schema.json`'s `cost` property lists
+      `input_tokens`, `output_tokens`, `model_tier`, `model`, `estimated_usd`,
+      `skip`, `skip_reason` with correct types.
+- [ ] A key-set drift check exists for both objects, added to
+      `manifest_schema_key_contracts()`-style table (or a sibling function)
+      and wired into `validate_agent_native_contracts`
+      (`crates/landmark/src/release_ops/contracts.rs:186`), so
+      `bin/check-action-contract` fails if the schema's declared keys and the
+      Rust struct's serialized field names diverge.
+- [ ] `bin/gate` passes.
+
+## Notes
+Verified live: `schemas/release-context.v1.schema.json`'s `classification` and
+`cost` properties are `{"type": "object"}` with no nested `properties` today
+(the top-level schema is deliberately loose via `additionalProperties: true`,
+but these two objects carry the highest-stakes agent-facing fields — the exact
+fields a disagreement-alarm-reading agent needs). The repo already has the
+right pattern for this: `manifest_schema_key_contracts()`
+(`crates/landmark/src/manifest.rs:417-465`) declares expected property-key
+sets per schema pointer, and `validate_manifest_schema_alignment`
+(`crates/landmark/src/release_ops/contracts.rs:439-453`) diffs them against
+the actual schema file using `schema.pointer(pointer)` — no external jsonschema crate needed. Reuse that
+exact mechanism, pointed at `release-context.v1.schema.json`'s
+`/properties/classification/properties` and `/properties/cost/properties`.
+VISION.md: "Agent-native contracts are first-class... `schemas/` ... are
+public surfaces, not internal conveniences" — this ticket makes that true for
+the two objects that changed shape most recently (tonight's classification
+work added `deterministic_signals`/`disagreements`).
+
+**Why:** confirmed no JSON-schema-validation-against-real-output exists
+anywhere in the test suite (`grep -rn "jsonschema\|schemars" crates/*/Cargo.toml`
+returns nothing); the closest existing check
+(`validate_agent_native_contracts`) only verifies `$id`/`x-landmark-artifact`
+and README/guide doc-token presence, not structural conformance.

--- a/backlog.d/014-document-cli-help-text.md
+++ b/backlog.d/014-document-cli-help-text.md
@@ -1,0 +1,53 @@
+# Add real --help text to every CLI subcommand and flag
+
+Priority: P2 · Status: ready · Estimate: M
+
+## Goal
+`landmark --help` and every subcommand's `--help` currently render blank
+descriptions for all 28 subcommands and nearly every flag. Add clap doc
+comments (`///`) so the CLI is self-describing for cold agents and humans,
+matching the agent-native-contract bar the rest of the repo already holds
+itself to.
+
+## Oracle
+- [ ] `cargo run --locked -- --help` shows a non-empty one-line description for
+      every subcommand listed under `Commands:` (currently: `describe`, `init`,
+      `doctor`, `manifest-defaults`, `healthcheck`, `preflight-tags`,
+      `fetch-release-body`, `extract-prs`, `synthesize`, `release-policy`,
+      `update-release`, `write-artifacts`, `update-feed`, `notify-webhook`,
+      `notify-slack`, `run`, `floating-tag`, `close-resolved-failures`,
+      `report-synthesis-failure`, `update-version-metadata`,
+      `check-version-sync`, `check-action-contract`, `replay-action`,
+      `backfill`, `setup`, `fleet`, `prepare-self-release`,
+      `publish-self-release`).
+- [ ] `cargo run --locked -- run --help`, `synthesize --help`, `backfill
+      --help`, `setup --help`, `fleet --help`, and `prepare-self-release
+      --help` (the highest-traffic subcommands per README/agent-integration
+      guide) show a non-empty description for every flag, not just its type
+      and default.
+- [ ] Descriptions are accurate against current behavior (source from README/
+      `docs/agent-integration.md`/existing doc comments elsewhere in the repo
+      where they already explain a flag; do not invent new semantics).
+- [ ] `bin/gate` passes (including `cargo clippy -D warnings`, which will
+      catch any malformed doc comments).
+
+## Notes
+Verified live: `cargo run --locked -q -- --help` prints every subcommand with
+a blank description; `cargo run --locked -q -- run --help` prints every flag
+(`--provider`, `--repo-root`, `--dry-run`, `--output-dir`, etc.) with no help
+text, only `[default: ...]`. `crates/landmark/src/cli.rs` (673 lines) has
+essentially zero `///` doc comments on its `#[derive(Parser)]`/`#[derive(Args)]`
+structs today (only the top-level `#[command(about = "...")]` on line 5 has
+text). clap renders `///` comments as `--help` output automatically — no
+new dependency or mechanism needed, purely additive doc comments.
+
+This directly serves AGENTS.md's own standing rule: "Keep README, action.yml,
+examples, and this file aligned. Stale agent-facing prose is a release risk
+because agents use it as an operating contract" — the CLI's own `--help` is
+the most agent-native surface of all and is currently silent. Large surface
+area (28 subcommands); land it incrementally if needed (top-level `about`
+text first, then flag-level help for the highest-traffic subcommands named
+above), but the oracle above is the floor for calling this done.
+
+**Why:** live-verified via direct `--help` invocation during this groom pass,
+not inferred from the teardown report (which did not flag this specific gap).

--- a/backlog.d/015-cover-remaining-failure-classification-branches.md
+++ b/backlog.d/015-cover-remaining-failure-classification-branches.md
@@ -1,0 +1,38 @@
+# Cover the remaining classify_failure branches with tests
+
+Priority: P2 · Status: ready · Estimate: S
+
+## Goal
+`classify_failure` (`crates/landmark/src/errors.rs:26-104`) is the function
+behind every `--error-format json` failure envelope's `code`/`stage`/
+`retryable`/`user_action` fields — an explicitly agent-native contract
+(`docs/agent-integration.md` documents it directly). Only 2 of its 10 branches
+have a pinned test today.
+
+## Oracle
+- [ ] A test exists for each remaining branch of `classify_failure`:
+      `provider_outage` (429/rate-limit/timeout), `budget_skip`
+      (budget/model.policy=off), `synthesis_degradation`
+      (degraded/quality), `publication_mutation_failure` (release
+      body/publish-release-body), `feed_failure` (rss/feed),
+      `artifact_write_failure` (write/file/permission), `invalid_input`
+      (unsupported provider/requires/must), and the `command_failed`
+      catch-all for a message matching none of the above.
+- [ ] Each test asserts `code`, `stage`, and `retryable` (not just that a
+      match occurred) so silent branch reordering or overlap regressions get
+      caught.
+- [ ] `cargo test --locked` and `bin/gate` pass.
+
+## Notes
+Verified live: `grep -rn "classify_failure" crates/landmark/src` shows only
+two call sites in `crates/landmark/src/tests.rs` (`--publish-release-body
+requires --github-token` and `manifest changelog.source must be auto`),
+covering `provider_auth` and `invalid_changelog_source` only. The function's
+branch order matters (it's a first-match `if`/`else if` chain over
+substring checks on a lowercased message), so untested branches are exactly
+where an added/reordered branch could silently steal matches from another
+without any test failing.
+
+**Why:** confirmed by direct `grep` during this groom pass; not called out in
+the teardown report, which focused on classification/version-decision rather
+than the failure-envelope taxonomy.


### PR DESCRIPTION
## Summary
Imports 5 new vetted, live-verified tickets from `~/.factory-lanes/refill/landmark/` into `backlog.d/` (011-015). No numbering collision with the existing queue (up to 010).

- **011 (P0)**: `release_kit::plan` still calls the plain-text classifier at `release_kit.rs:173`, missing the structured-classifier fix already landed for `synthesis.rs` — a second call site of the same misfire class the groom teardown flagged.
- **012 (P1)**: `release_kit.rs` (990 lines) has zero unit tests on its importance/audience/rich-artifact decision functions.
- **013 (P1)**: `release-context.v1.schema.json`'s `classification`/`cost` objects are bare `{"type": "object"}` with no drift check against the Rust structs.
- **014 (P2)**: every CLI subcommand and nearly every flag renders blank `--help` text.
- **015 (P2)**: `classify_failure`'s failure-envelope taxonomy has only 2 of 10 branches under test.

Spot-verified each ticket's live claims before importing (grep confirmed the `release_kit.rs:173` call site, zero `#[test]` in `release_kit.rs`, blank `--help` output, and only 2 tested `classify_failure` branches).

## Test plan
- [x] `cargo test --locked` (65 tests, unaffected — docs-only import), `check-action-contract` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)