### PR TITLE
fix(release-kit): populate changed_files in the deterministic context

### DIFF
--- a/crates/landmark/src/release_kit.rs
+++ b/crates/landmark/src/release_kit.rs
@@ -1,8 +1,8 @@
 use super::{
     ContextCommit, DeterministicReleaseContext, LandmarkManifest, Result, RunArgs,
     RunArtifactRecord, RunPublicationRecord, RunReleaseContext, RunVersionDecision,
-    classify_release_context_with_deterministic, context_source, conventional_commit_type,
-    is_breaking_commit, sha256_hex, trimmed_option,
+    classify_release_context_with_deterministic, context_changed_files, context_source,
+    conventional_commit_type, is_breaking_commit, sha256_hex, trimmed_option,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -186,6 +186,7 @@ pub(super) fn plan(input: PlanInput<'_>) -> ReleaseKit {
                 short_hash: commit.short_hash.clone(),
             })
             .collect(),
+        changed_files: context_changed_files(&args.repo_root, &release.version),
         ..DeterministicReleaseContext::default()
     };
     let release_classification = classify_release_context_with_deterministic(


### PR DESCRIPTION
## Summary
Fresh-context critic review of #177 caught this: `release_kit::plan`'s new `DeterministicReleaseContext` left `changed_files` empty (only `release.commits` was populated), unlike `synthesis.rs`'s sibling construction which fully populates it via `context_changed_files`.

Two real effects of the gap:
- The `.github/`/`scripts/` internal-tooling changed-file signal was permanently unreachable through this path, even though `PlanInput` already carries `repo_root` and `version`.
- The docs-only "all changed files are markdown" check was vacuously true on an empty list, silently inserting a `docs-only` category on every release regardless of what actually changed (harmless today since `plan()` only reads `significance`/`breaking`/`security`/`migration_heavy`/`reasons` off the classification, not `.categories` — but worth closing rather than leaving latent).

Reuses `context_changed_files(repo_root, version)` directly — the same helper `synthesis.rs` already uses, which gracefully returns an empty `Vec` on any git error via `run_ok(...).unwrap_or_default()`, so this can't turn a working `plan()` call into a failing one.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked` (65 tests) all green
- [x] `cargo run --locked -- replay-action` — all 25 scenarios pass
- [x] `check-action-contract`, `check-version-sync`, `bin/check-architecture` (release_kit.rs still well under its 1050 cap at 1013 lines), `git diff --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)