### PR TITLE
test(release-kit): split contract validation out, pin the decision matrix

### DIFF
--- a/backlog.d/_done/012-test-release-kit-importance-matrix.md
+++ b/backlog.d/_done/012-test-release-kit-importance-matrix.md
@@ -1,6 +1,6 @@
 # Pin release_kit's importance/audience/rich-artifact decision matrix with unit tests
 
-Priority: P1 · Status: ready · Estimate: S
+Priority: P1 · Status: done · Estimate: S
 
 ## Goal
 `crates/landmark/src/release_kit.rs` has zero `#[test]` functions covering
@@ -11,7 +11,7 @@ patches, blog drafts, demo videos) get planned for a release. Add direct unit
 tests pinning the existing decision table so it can't silently drift.
 
 ## Oracle
-- [ ] `release_kit_importance` (`release_kit.rs:460`, line numbers shift as
+- [x] `release_kit_importance` (`release_kit.rs:460`, line numbers shift as
       011 and this ticket land — grep for the function name, don't trust the
       line number) has a test per branch: `security` (classification.security),
       `migration` (major bump, or classification.breaking, or
@@ -20,28 +20,27 @@ tests pinning the existing decision table so it can't silently drift.
       `medium` fallback — constructed directly from
       `ReleaseClassification`/`RunVersionDecision` values, not through the
       full `plan()` pipeline.
-- [ ] `release_kit_audiences` (`release_kit.rs:480`) has a test proving
+- [x] `release_kit_audiences` (`release_kit.rs:480`) has a test proving
       `release-operator`/`docs-owner` are added only when
       `release_kit_needs_rich_artifacts(importance)` is true, and the primary
       audience plus `developer-operator` are always present.
-- [ ] `release_kit_needs_rich_artifacts` (`release_kit.rs:491`) has a test
+- [x] `release_kit_needs_rich_artifacts` (`release_kit.rs:491`) has a test
       naming every importance value it treats as needing rich artifacts vs not.
-- [ ] `cargo test --locked` and `bin/gate` pass.
+- [x] `cargo test --locked` and `bin/gate` pass.
 
 ## Split ownership before adding, not after
-011 landed release_kit.rs at 1012 lines (a deliberate, explicitly-reasoned
-`bin/check-architecture` bump to 1050 — see that script's comment — not a
-blank check). Adding this ticket's tests without splitting the file risks
-hitting that cap again immediately. `assert_contract` and its supporting
+Done as part of this ticket: `assert_contract` and its supporting
 JSON-schema-shape validators (`assert_json_eq`, `assert_schema_contract`,
 `assert_supported_schema_keywords`, `collect_unsupported_schema_keywords`,
 `supported_schema_keyword`, `validate_contract_schema_node`,
-`validate_object_schema_node`, `validate_array_schema_node`, `json_type` —
-roughly release_kit.rs:670 to end) is a self-contained, separable concern
-(validating release-kit JSON shape against its schema) from the
-plan/build/artifact-decision logic this ticket is testing. Split that block
-into its own module (e.g. `release_kit_contract.rs`) as part of this ticket,
-before adding new tests, rather than growing the combined file further.
+`validate_object_schema_node`, `validate_array_schema_node`, `json_type`)
+moved to `crates/landmark/src/release_kit_contract.rs`. `release_kit.rs`
+dropped from 1012 to 666 lines; `bin/check-architecture`'s cap reverted from
+the deliberate 011 bump (1050) back down to 1000, headroom restored rather
+than spent. New tests live in `crates/landmark/src/release_kit_tests.rs`
+(mirroring the `version_decision_tests.rs` pattern), reaching the three
+target functions via a small `pub(crate)` visibility bump (they were bare
+`fn`, private to `release_kit.rs`).
 
 ## Notes
 Verified live: `grep -rn "fn.*release_kit\|#\[test\]" crates/landmark/src/release_kit.rs`

--- a/bin/check-architecture
+++ b/bin/check-architecture
@@ -21,12 +21,7 @@ check_max_lines() {
 }
 
 check_max_lines "crates/landmark/src/main.rs" 120
-# release_kit.rs grew past 1000 landing backlog 011 (structured-commit
-# classification, closing the second bare-text classifier misfire site).
-# Small, deliberate headroom bump, not a blank check: backlog 012 adds direct
-# unit tests to this file next and will need to split ownership (plan/build
-# vs. assert_contract validation) rather than raise this cap again.
-check_max_lines "crates/landmark/src/release_kit.rs" 1050
+check_max_lines "crates/landmark/src/release_kit.rs" 1000
 
 while IFS= read -r path; do
   case "${path}" in

--- a/crates/landmark/src/main.rs
+++ b/crates/landmark/src/main.rs
@@ -28,6 +28,9 @@ mod manifest;
 mod providers;
 mod release_classification;
 mod release_kit;
+mod release_kit_contract;
+#[cfg(test)]
+mod release_kit_tests;
 mod release_ops;
 mod replay;
 mod self_release;

--- a/crates/landmark/src/release_kit.rs
+++ b/crates/landmark/src/release_kit.rs
@@ -1,17 +1,14 @@
 use super::{
-    ContextCommit, DeterministicReleaseContext, LandmarkManifest, Result, RunArgs,
-    RunArtifactRecord, RunPublicationRecord, RunReleaseContext, RunVersionDecision,
+    ContextCommit, DeterministicReleaseContext, LandmarkManifest, RunArgs, RunArtifactRecord,
+    RunPublicationRecord, RunReleaseContext, RunVersionDecision,
     classify_release_context_with_deterministic, context_changed_files, context_source,
     conventional_commit_type, is_breaking_commit, sha256_hex, trimmed_option,
 };
 use serde::Serialize;
-use serde_json::Value;
 use std::collections::BTreeSet;
-use std::env;
-use std::fs;
 use std::path::PathBuf;
 
-const SCHEMA_VERSION: &str = "landmark.release-kit.v1";
+pub(crate) const SCHEMA_VERSION: &str = "landmark.release-kit.v1";
 const PRODUCER_EVIDENCE_DIR: &str = ".landmark/run/producers";
 
 #[derive(Clone, Debug, Serialize)]
@@ -458,7 +455,7 @@ fn artifact_status(dry_run: bool, path: &str) -> String {
     }
 }
 
-fn release_kit_importance(
+pub(crate) fn release_kit_importance(
     classification: &super::ReleaseClassification,
     decision: &RunVersionDecision,
 ) -> String {
@@ -478,7 +475,7 @@ fn release_kit_importance(
     }
 }
 
-fn release_kit_audiences(primary: &str, importance: &str) -> Vec<String> {
+pub(crate) fn release_kit_audiences(primary: &str, importance: &str) -> Vec<String> {
     let mut audiences = BTreeSet::new();
     audiences.insert(primary.to_string());
     audiences.insert("developer-operator".into());
@@ -489,7 +486,7 @@ fn release_kit_audiences(primary: &str, importance: &str) -> Vec<String> {
     audiences.into_iter().collect()
 }
 
-fn release_kit_needs_rich_artifacts(importance: &str) -> bool {
+pub(crate) fn release_kit_needs_rich_artifacts(importance: &str) -> bool {
     matches!(importance, "high" | "launch" | "migration" | "security")
 }
 
@@ -665,349 +662,5 @@ impl ProducerCommand {
                 )
             }
         }
-    }
-}
-
-fn assert_json_eq(value: &Value, pointer: &str, expected: &str, label: &str) -> Result<()> {
-    let actual = value
-        .pointer(pointer)
-        .and_then(Value::as_str)
-        .ok_or_else(|| format!("{label} missing JSON string at {pointer}"))?;
-    if actual != expected {
-        return Err(format!("{label} expected `{expected}`, got `{actual}`").into());
-    }
-    Ok(())
-}
-
-pub(super) fn assert_contract(value: &Value, label: &str) -> Result<()> {
-    assert_schema_contract(value, label)?;
-    assert_json_eq(value, "/schema_version", SCHEMA_VERSION, label)?;
-    for pointer in [
-        "/generated_at",
-        "/product/name",
-        "/release/tag",
-        "/classification/importance",
-        "/classification/why_it_matters",
-        "/status/summary",
-    ] {
-        if value
-            .pointer(pointer)
-            .and_then(Value::as_str)
-            .unwrap_or_default()
-            .trim()
-            .is_empty()
-        {
-            return Err(format!("{label} missing required string at {pointer}").into());
-        }
-    }
-    for pointer in [
-        "/classification/audiences",
-        "/artifacts",
-        "/provenance",
-        "/approvals",
-    ] {
-        if value
-            .pointer(pointer)
-            .and_then(Value::as_array)
-            .is_none_or(|items| items.is_empty())
-        {
-            return Err(format!("{label} missing non-empty array at {pointer}").into());
-        }
-    }
-    if !value["producer_contracts"].is_array() {
-        return Err(format!("{label} producer_contracts must be an array").into());
-    }
-    let artifacts = value["artifacts"]
-        .as_array()
-        .ok_or_else(|| format!("{label} artifacts must be an array"))?;
-    let artifact_ids: BTreeSet<String> = artifacts
-        .iter()
-        .filter_map(|artifact| artifact["id"].as_str().map(str::to_string))
-        .collect();
-    for artifact in artifacts {
-        for pointer in ["/id", "/kind", "/audience", "/owner", "/status"] {
-            if artifact
-                .pointer(pointer)
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .trim()
-                .is_empty()
-            {
-                return Err(format!("{label} artifact missing string at {pointer}").into());
-            }
-        }
-        if artifact["acceptance"]
-            .as_array()
-            .is_none_or(|items| items.is_empty())
-        {
-            return Err(format!("{label} artifact missing acceptance checks").into());
-        }
-    }
-    for provenance in value["provenance"]
-        .as_array()
-        .ok_or_else(|| format!("{label} provenance must be an array"))?
-    {
-        let artifact_id = provenance["artifact_id"].as_str().unwrap_or_default();
-        if !artifact_ids.contains(artifact_id) {
-            return Err(
-                format!("{label} provenance references unknown artifact `{artifact_id}`").into(),
-            );
-        }
-        if provenance["sources"]
-            .as_array()
-            .is_none_or(|items| items.is_empty())
-        {
-            return Err(format!("{label} provenance missing sources").into());
-        }
-    }
-    for approval in value["approvals"]
-        .as_array()
-        .ok_or_else(|| format!("{label} approvals must be an array"))?
-    {
-        let artifact_id = approval["artifact_id"].as_str().unwrap_or_default();
-        if !artifact_ids.contains(artifact_id) {
-            return Err(
-                format!("{label} approval references unknown artifact `{artifact_id}`").into(),
-            );
-        }
-        if approval["state"].as_str().unwrap_or_default().is_empty() {
-            return Err(format!("{label} approval missing state").into());
-        }
-    }
-    for contract in value["producer_contracts"]
-        .as_array()
-        .ok_or_else(|| format!("{label} producer_contracts must be an array"))?
-    {
-        for pointer in [
-            "/id",
-            "/producer",
-            "/adapter_kind",
-            "/command",
-            "/evidence_path",
-        ] {
-            if contract
-                .pointer(pointer)
-                .and_then(Value::as_str)
-                .unwrap_or_default()
-                .trim()
-                .is_empty()
-            {
-                return Err(
-                    format!("{label} producer contract missing string at {pointer}").into(),
-                );
-            }
-        }
-        if !contract["mutates"].is_boolean() {
-            return Err(format!("{label} producer contract missing mutates boolean").into());
-        }
-        for pointer in ["/input_artifacts", "/output_artifacts", "/acceptance"] {
-            if contract
-                .pointer(pointer)
-                .and_then(Value::as_array)
-                .is_none_or(|items| items.is_empty())
-            {
-                return Err(format!(
-                    "{label} producer contract missing non-empty array at {pointer}"
-                )
-                .into());
-            }
-        }
-        for pointer in ["/input_artifacts", "/output_artifacts"] {
-            for artifact_id in contract
-                .pointer(pointer)
-                .and_then(Value::as_array)
-                .into_iter()
-                .flatten()
-                .filter_map(Value::as_str)
-            {
-                if !artifact_ids.contains(artifact_id) {
-                    return Err(format!(
-                        "{label} producer contract references unknown artifact `{artifact_id}`"
-                    )
-                    .into());
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-fn assert_schema_contract(value: &Value, label: &str) -> Result<()> {
-    let schema_path = env::current_dir()?.join("schemas/release-kit.v1.schema.json");
-    let schema: Value = serde_json::from_str(&fs::read_to_string(&schema_path)?)?;
-    assert_supported_schema_keywords(&schema, &schema_path)?;
-    let mut errors = Vec::new();
-    validate_contract_schema_node(&schema, value, "$", &mut errors);
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(format!(
-            "{label} does not validate against {}:\n{}",
-            schema_path.display(),
-            errors.join("\n")
-        )
-        .into())
-    }
-}
-
-fn assert_supported_schema_keywords(schema: &Value, schema_path: &std::path::Path) -> Result<()> {
-    let mut unsupported = Vec::new();
-    collect_unsupported_schema_keywords(schema, "$", &mut unsupported);
-    if unsupported.is_empty() {
-        Ok(())
-    } else {
-        Err(format!(
-            "{} uses unsupported JSON Schema keywords for Landmark's replay contract checker:\n{}",
-            schema_path.display(),
-            unsupported.join("\n")
-        )
-        .into())
-    }
-}
-
-fn collect_unsupported_schema_keywords(schema: &Value, path: &str, errors: &mut Vec<String>) {
-    let Some(object) = schema.as_object() else {
-        return;
-    };
-    for key in object.keys() {
-        if key.starts_with("x-") || supported_schema_keyword(key) {
-            continue;
-        }
-        errors.push(format!("{path} unsupported keyword `{key}`"));
-    }
-    if let Some(properties) = object.get("properties").and_then(Value::as_object) {
-        for (property, property_schema) in properties {
-            collect_unsupported_schema_keywords(
-                property_schema,
-                &format!("{path}/properties/{property}"),
-                errors,
-            );
-        }
-    }
-    if let Some(item_schema) = object.get("items") {
-        collect_unsupported_schema_keywords(item_schema, &format!("{path}/items"), errors);
-    }
-}
-
-fn supported_schema_keyword(keyword: &str) -> bool {
-    matches!(
-        keyword,
-        "$schema"
-            | "$id"
-            | "title"
-            | "type"
-            | "additionalProperties"
-            | "required"
-            | "properties"
-            | "const"
-            | "enum"
-            | "items"
-    )
-}
-
-fn validate_contract_schema_node(
-    schema: &Value,
-    value: &Value,
-    path: &str,
-    errors: &mut Vec<String>,
-) {
-    if let Some(expected) = schema.get("const")
-        && value != expected
-    {
-        errors.push(format!("{path} expected const {expected}, got {value}"));
-    }
-    if let Some(variants) = schema.get("enum").and_then(Value::as_array)
-        && !variants.iter().any(|variant| variant == value)
-    {
-        errors.push(format!("{path} expected one of {variants:?}, got {value}"));
-    }
-    let Some(schema_type) = schema.get("type").and_then(Value::as_str) else {
-        return;
-    };
-    match schema_type {
-        "object" => validate_object_schema_node(schema, value, path, errors),
-        "array" => validate_array_schema_node(schema, value, path, errors),
-        "string" if !value.is_string() => {
-            errors.push(format!("{path} expected string, got {}", json_type(value)));
-        }
-        "boolean" if !value.is_boolean() => {
-            errors.push(format!("{path} expected boolean, got {}", json_type(value)));
-        }
-        "integer" if !value.is_i64() && !value.is_u64() => {
-            errors.push(format!("{path} expected integer, got {}", json_type(value)));
-        }
-        "number" if !value.is_number() => {
-            errors.push(format!("{path} expected number, got {}", json_type(value)));
-        }
-        _ => {}
-    }
-}
-
-fn validate_object_schema_node(
-    schema: &Value,
-    value: &Value,
-    path: &str,
-    errors: &mut Vec<String>,
-) {
-    let Some(object) = value.as_object() else {
-        errors.push(format!("{path} expected object, got {}", json_type(value)));
-        return;
-    };
-    let required: BTreeSet<&str> = schema
-        .get("required")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(Value::as_str)
-        .collect();
-    for key in &required {
-        if !object.contains_key(*key) {
-            errors.push(format!("{path} missing required property `{key}`"));
-        }
-    }
-    let properties = schema
-        .get("properties")
-        .and_then(Value::as_object)
-        .cloned()
-        .unwrap_or_default();
-    if schema.get("additionalProperties") == Some(&Value::Bool(false)) {
-        for key in object.keys() {
-            if !properties.contains_key(key) {
-                errors.push(format!("{path} has unexpected property `{key}`"));
-            }
-        }
-    }
-    for (key, property_schema) in properties {
-        if let Some(child) = object.get(&key) {
-            validate_contract_schema_node(
-                &property_schema,
-                child,
-                &format!("{path}/{key}"),
-                errors,
-            );
-        }
-    }
-}
-
-fn validate_array_schema_node(schema: &Value, value: &Value, path: &str, errors: &mut Vec<String>) {
-    let Some(items) = value.as_array() else {
-        errors.push(format!("{path} expected array, got {}", json_type(value)));
-        return;
-    };
-    if let Some(item_schema) = schema.get("items") {
-        for (index, item) in items.iter().enumerate() {
-            validate_contract_schema_node(item_schema, item, &format!("{path}/{index}"), errors);
-        }
-    }
-}
-
-fn json_type(value: &Value) -> &'static str {
-    match value {
-        Value::Null => "null",
-        Value::Bool(_) => "boolean",
-        Value::Number(_) => "number",
-        Value::String(_) => "string",
-        Value::Array(_) => "array",
-        Value::Object(_) => "object",
     }
 }

--- a/crates/landmark/src/release_kit_contract.rs
+++ b/crates/landmark/src/release_kit_contract.rs
@@ -1,0 +1,350 @@
+use super::Result;
+use super::release_kit::SCHEMA_VERSION;
+use serde_json::Value;
+use std::collections::BTreeSet;
+use std::env;
+use std::fs;
+
+fn assert_json_eq(value: &Value, pointer: &str, expected: &str, label: &str) -> Result<()> {
+    let actual = value
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{label} missing JSON string at {pointer}"))?;
+    if actual != expected {
+        return Err(format!("{label} expected `{expected}`, got `{actual}`").into());
+    }
+    Ok(())
+}
+
+pub(crate) fn assert_contract(value: &Value, label: &str) -> Result<()> {
+    assert_schema_contract(value, label)?;
+    assert_json_eq(value, "/schema_version", SCHEMA_VERSION, label)?;
+    for pointer in [
+        "/generated_at",
+        "/product/name",
+        "/release/tag",
+        "/classification/importance",
+        "/classification/why_it_matters",
+        "/status/summary",
+    ] {
+        if value
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+        {
+            return Err(format!("{label} missing required string at {pointer}").into());
+        }
+    }
+    for pointer in [
+        "/classification/audiences",
+        "/artifacts",
+        "/provenance",
+        "/approvals",
+    ] {
+        if value
+            .pointer(pointer)
+            .and_then(Value::as_array)
+            .is_none_or(|items| items.is_empty())
+        {
+            return Err(format!("{label} missing non-empty array at {pointer}").into());
+        }
+    }
+    if !value["producer_contracts"].is_array() {
+        return Err(format!("{label} producer_contracts must be an array").into());
+    }
+    let artifacts = value["artifacts"]
+        .as_array()
+        .ok_or_else(|| format!("{label} artifacts must be an array"))?;
+    let artifact_ids: BTreeSet<String> = artifacts
+        .iter()
+        .filter_map(|artifact| artifact["id"].as_str().map(str::to_string))
+        .collect();
+    for artifact in artifacts {
+        for pointer in ["/id", "/kind", "/audience", "/owner", "/status"] {
+            if artifact
+                .pointer(pointer)
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
+            {
+                return Err(format!("{label} artifact missing string at {pointer}").into());
+            }
+        }
+        if artifact["acceptance"]
+            .as_array()
+            .is_none_or(|items| items.is_empty())
+        {
+            return Err(format!("{label} artifact missing acceptance checks").into());
+        }
+    }
+    for provenance in value["provenance"]
+        .as_array()
+        .ok_or_else(|| format!("{label} provenance must be an array"))?
+    {
+        let artifact_id = provenance["artifact_id"].as_str().unwrap_or_default();
+        if !artifact_ids.contains(artifact_id) {
+            return Err(
+                format!("{label} provenance references unknown artifact `{artifact_id}`").into(),
+            );
+        }
+        if provenance["sources"]
+            .as_array()
+            .is_none_or(|items| items.is_empty())
+        {
+            return Err(format!("{label} provenance missing sources").into());
+        }
+    }
+    for approval in value["approvals"]
+        .as_array()
+        .ok_or_else(|| format!("{label} approvals must be an array"))?
+    {
+        let artifact_id = approval["artifact_id"].as_str().unwrap_or_default();
+        if !artifact_ids.contains(artifact_id) {
+            return Err(
+                format!("{label} approval references unknown artifact `{artifact_id}`").into(),
+            );
+        }
+        if approval["state"].as_str().unwrap_or_default().is_empty() {
+            return Err(format!("{label} approval missing state").into());
+        }
+    }
+    for contract in value["producer_contracts"]
+        .as_array()
+        .ok_or_else(|| format!("{label} producer_contracts must be an array"))?
+    {
+        for pointer in [
+            "/id",
+            "/producer",
+            "/adapter_kind",
+            "/command",
+            "/evidence_path",
+        ] {
+            if contract
+                .pointer(pointer)
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
+            {
+                return Err(
+                    format!("{label} producer contract missing string at {pointer}").into(),
+                );
+            }
+        }
+        if !contract["mutates"].is_boolean() {
+            return Err(format!("{label} producer contract missing mutates boolean").into());
+        }
+        for pointer in ["/input_artifacts", "/output_artifacts", "/acceptance"] {
+            if contract
+                .pointer(pointer)
+                .and_then(Value::as_array)
+                .is_none_or(|items| items.is_empty())
+            {
+                return Err(format!(
+                    "{label} producer contract missing non-empty array at {pointer}"
+                )
+                .into());
+            }
+        }
+        for pointer in ["/input_artifacts", "/output_artifacts"] {
+            for artifact_id in contract
+                .pointer(pointer)
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+            {
+                if !artifact_ids.contains(artifact_id) {
+                    return Err(format!(
+                        "{label} producer contract references unknown artifact `{artifact_id}`"
+                    )
+                    .into());
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn assert_schema_contract(value: &Value, label: &str) -> Result<()> {
+    let schema_path = env::current_dir()?.join("schemas/release-kit.v1.schema.json");
+    let schema: Value = serde_json::from_str(&fs::read_to_string(&schema_path)?)?;
+    assert_supported_schema_keywords(&schema, &schema_path)?;
+    let mut errors = Vec::new();
+    validate_contract_schema_node(&schema, value, "$", &mut errors);
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{label} does not validate against {}:\n{}",
+            schema_path.display(),
+            errors.join("\n")
+        )
+        .into())
+    }
+}
+
+fn assert_supported_schema_keywords(schema: &Value, schema_path: &std::path::Path) -> Result<()> {
+    let mut unsupported = Vec::new();
+    collect_unsupported_schema_keywords(schema, "$", &mut unsupported);
+    if unsupported.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "{} uses unsupported JSON Schema keywords for Landmark's replay contract checker:\n{}",
+            schema_path.display(),
+            unsupported.join("\n")
+        )
+        .into())
+    }
+}
+
+fn collect_unsupported_schema_keywords(schema: &Value, path: &str, errors: &mut Vec<String>) {
+    let Some(object) = schema.as_object() else {
+        return;
+    };
+    for key in object.keys() {
+        if key.starts_with("x-") || supported_schema_keyword(key) {
+            continue;
+        }
+        errors.push(format!("{path} unsupported keyword `{key}`"));
+    }
+    if let Some(properties) = object.get("properties").and_then(Value::as_object) {
+        for (property, property_schema) in properties {
+            collect_unsupported_schema_keywords(
+                property_schema,
+                &format!("{path}/properties/{property}"),
+                errors,
+            );
+        }
+    }
+    if let Some(item_schema) = object.get("items") {
+        collect_unsupported_schema_keywords(item_schema, &format!("{path}/items"), errors);
+    }
+}
+
+fn supported_schema_keyword(keyword: &str) -> bool {
+    matches!(
+        keyword,
+        "$schema"
+            | "$id"
+            | "title"
+            | "type"
+            | "additionalProperties"
+            | "required"
+            | "properties"
+            | "const"
+            | "enum"
+            | "items"
+    )
+}
+
+fn validate_contract_schema_node(
+    schema: &Value,
+    value: &Value,
+    path: &str,
+    errors: &mut Vec<String>,
+) {
+    if let Some(expected) = schema.get("const")
+        && value != expected
+    {
+        errors.push(format!("{path} expected const {expected}, got {value}"));
+    }
+    if let Some(variants) = schema.get("enum").and_then(Value::as_array)
+        && !variants.iter().any(|variant| variant == value)
+    {
+        errors.push(format!("{path} expected one of {variants:?}, got {value}"));
+    }
+    let Some(schema_type) = schema.get("type").and_then(Value::as_str) else {
+        return;
+    };
+    match schema_type {
+        "object" => validate_object_schema_node(schema, value, path, errors),
+        "array" => validate_array_schema_node(schema, value, path, errors),
+        "string" if !value.is_string() => {
+            errors.push(format!("{path} expected string, got {}", json_type(value)));
+        }
+        "boolean" if !value.is_boolean() => {
+            errors.push(format!("{path} expected boolean, got {}", json_type(value)));
+        }
+        "integer" if !value.is_i64() && !value.is_u64() => {
+            errors.push(format!("{path} expected integer, got {}", json_type(value)));
+        }
+        "number" if !value.is_number() => {
+            errors.push(format!("{path} expected number, got {}", json_type(value)));
+        }
+        _ => {}
+    }
+}
+
+fn validate_object_schema_node(
+    schema: &Value,
+    value: &Value,
+    path: &str,
+    errors: &mut Vec<String>,
+) {
+    let Some(object) = value.as_object() else {
+        errors.push(format!("{path} expected object, got {}", json_type(value)));
+        return;
+    };
+    let required: BTreeSet<&str> = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect();
+    for key in &required {
+        if !object.contains_key(*key) {
+            errors.push(format!("{path} missing required property `{key}`"));
+        }
+    }
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if schema.get("additionalProperties") == Some(&Value::Bool(false)) {
+        for key in object.keys() {
+            if !properties.contains_key(key) {
+                errors.push(format!("{path} has unexpected property `{key}`"));
+            }
+        }
+    }
+    for (key, property_schema) in properties {
+        if let Some(child) = object.get(&key) {
+            validate_contract_schema_node(
+                &property_schema,
+                child,
+                &format!("{path}/{key}"),
+                errors,
+            );
+        }
+    }
+}
+
+fn validate_array_schema_node(schema: &Value, value: &Value, path: &str, errors: &mut Vec<String>) {
+    let Some(items) = value.as_array() else {
+        errors.push(format!("{path} expected array, got {}", json_type(value)));
+        return;
+    };
+    if let Some(item_schema) = schema.get("items") {
+        for (index, item) in items.iter().enumerate() {
+            validate_contract_schema_node(item_schema, item, &format!("{path}/{index}"), errors);
+        }
+    }
+}
+
+fn json_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}

--- a/crates/landmark/src/release_kit_tests.rs
+++ b/crates/landmark/src/release_kit_tests.rs
@@ -1,0 +1,176 @@
+use super::release_kit::{
+    release_kit_audiences, release_kit_importance, release_kit_needs_rich_artifacts,
+};
+use super::*;
+
+fn baseline_classification() -> ReleaseClassification {
+    ReleaseClassification {
+        categories: vec!["user-visible".into()],
+        significance: "medium".into(),
+        user_visible: true,
+        breaking: false,
+        security: false,
+        migration_heavy: false,
+        source: "structured".into(),
+        model: String::new(),
+        deterministic_signals: Vec::new(),
+        disagreements: Vec::new(),
+        reasons: Vec::new(),
+    }
+}
+
+fn baseline_decision() -> RunVersionDecision {
+    RunVersionDecision {
+        latest_tag: "v1.0.0".into(),
+        bump: "minor".into(),
+        commit_count: 1,
+        conventional_commit_count: 1,
+        range: "v1.0.0..HEAD".into(),
+        decisive_commit: None,
+        unknown_commits: Vec::new(),
+    }
+}
+
+#[test]
+fn importance_is_security_when_classification_flags_security() {
+    let mut classification = baseline_classification();
+    classification.security = true;
+    // Security wins even alongside signals that would otherwise say migration/high.
+    classification.breaking = true;
+    classification.significance = "high".into();
+    let importance = release_kit_importance(&classification, &baseline_decision());
+    assert_eq!(importance, "security");
+}
+
+#[test]
+fn importance_is_migration_for_major_bump_breaking_or_migration_heavy() {
+    let decision_major = RunVersionDecision {
+        bump: "major".into(),
+        ..baseline_decision()
+    };
+    assert_eq!(
+        release_kit_importance(&baseline_classification(), &decision_major),
+        "migration"
+    );
+
+    let mut breaking_classification = baseline_classification();
+    breaking_classification.breaking = true;
+    assert_eq!(
+        release_kit_importance(&breaking_classification, &baseline_decision()),
+        "migration"
+    );
+
+    let mut migration_heavy_classification = baseline_classification();
+    migration_heavy_classification.migration_heavy = true;
+    assert_eq!(
+        release_kit_importance(&migration_heavy_classification, &baseline_decision()),
+        "migration"
+    );
+}
+
+#[test]
+fn importance_is_high_for_high_significance() {
+    let mut classification = baseline_classification();
+    classification.significance = "high".into();
+    assert_eq!(
+        release_kit_importance(&classification, &baseline_decision()),
+        "high"
+    );
+}
+
+#[test]
+fn importance_is_launch_for_bootstrap_release_with_a_real_bump() {
+    let decision = RunVersionDecision {
+        latest_tag: String::new(),
+        bump: "minor".into(),
+        ..baseline_decision()
+    };
+    assert_eq!(
+        release_kit_importance(&baseline_classification(), &decision),
+        "launch"
+    );
+}
+
+#[test]
+fn importance_is_not_launch_when_bootstrap_has_no_bump() {
+    let decision = RunVersionDecision {
+        latest_tag: String::new(),
+        bump: "none".into(),
+        ..baseline_decision()
+    };
+    // No latest tag but also no bump: falls through to the medium default,
+    // not launch -- "launch" specifically means a bootstrap release that
+    // actually has release-worthy signal.
+    assert_eq!(
+        release_kit_importance(&baseline_classification(), &decision),
+        "medium"
+    );
+}
+
+#[test]
+fn importance_is_low_for_low_significance() {
+    let mut classification = baseline_classification();
+    classification.significance = "low".into();
+    assert_eq!(
+        release_kit_importance(&classification, &baseline_decision()),
+        "low"
+    );
+}
+
+#[test]
+fn importance_defaults_to_medium() {
+    assert_eq!(
+        release_kit_importance(&baseline_classification(), &baseline_decision()),
+        "medium"
+    );
+}
+
+#[test]
+fn needs_rich_artifacts_matches_exactly_high_launch_migration_security() {
+    for importance in ["high", "launch", "migration", "security"] {
+        assert!(
+            release_kit_needs_rich_artifacts(importance),
+            "{importance} should need rich artifacts"
+        );
+    }
+    for importance in ["medium", "low", "unknown", ""] {
+        assert!(
+            !release_kit_needs_rich_artifacts(importance),
+            "{importance} should not need rich artifacts"
+        );
+    }
+}
+
+#[test]
+fn audiences_always_include_primary_and_developer_operator() {
+    let audiences = release_kit_audiences("enterprise", "low");
+    assert!(audiences.contains(&"enterprise".to_string()));
+    assert!(audiences.contains(&"developer-operator".to_string()));
+    assert_eq!(audiences.len(), 2);
+}
+
+#[test]
+fn audiences_add_release_operator_and_docs_owner_only_when_rich_artifacts_needed() {
+    for importance in ["high", "launch", "migration", "security"] {
+        let audiences = release_kit_audiences("general", importance);
+        assert!(
+            audiences.contains(&"release-operator".to_string()),
+            "{importance} should add release-operator"
+        );
+        assert!(
+            audiences.contains(&"docs-owner".to_string()),
+            "{importance} should add docs-owner"
+        );
+    }
+    for importance in ["medium", "low"] {
+        let audiences = release_kit_audiences("general", importance);
+        assert!(
+            !audiences.contains(&"release-operator".to_string()),
+            "{importance} should not add release-operator"
+        );
+        assert!(
+            !audiences.contains(&"docs-owner".to_string()),
+            "{importance} should not add docs-owner"
+        );
+    }
+}

--- a/crates/landmark/src/replay/contract_scenarios.rs
+++ b/crates/landmark/src/replay/contract_scenarios.rs
@@ -317,7 +317,7 @@ pub(crate) fn scenario_agent_native_contracts(tmp_root: &Path) -> Result<Value> 
     }
     let evidence: Value = serde_json::from_slice(&dry_run.stdout)?;
     assert_json_eq(&evidence, "/provider", "local", "dry-run provider")?;
-    release_kit::assert_contract(&evidence["release_kit"], "dry-run release kit")?;
+    release_kit_contract::assert_contract(&evidence["release_kit"], "dry-run release kit")?;
     assert_json_eq(
         &evidence,
         "/artifacts/release_kit_schema",

--- a/crates/landmark/src/replay/provider_scenarios/provider_runs.rs
+++ b/crates/landmark/src/replay/provider_scenarios/provider_runs.rs
@@ -135,7 +135,7 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
                 .into(),
         );
     }
-    release_kit::assert_contract(&evidence["release_kit"], "local run release kit")?;
+    release_kit_contract::assert_contract(&evidence["release_kit"], "local run release kit")?;
     let markdown = repo.join("docs/releases/v1.1.0.md");
     let plaintext = repo.join("docs/releases/v1.1.0.txt");
     let html = repo.join("docs/releases/v1.1.0.html");
@@ -282,7 +282,10 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
     {
         return Err("local run did not treat BREAKING CHANGE footer as a major bump".into());
     }
-    release_kit::assert_contract(&breaking_evidence["release_kit"], "breaking release kit")?;
+    release_kit_contract::assert_contract(
+        &breaking_evidence["release_kit"],
+        "breaking release kit",
+    )?;
     let breaking_artifacts = breaking_evidence["release_kit"]["artifacts"]
         .as_array()
         .ok_or("breaking release kit artifacts missing")?;
@@ -357,7 +360,10 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
     let internal_evidence_path = internal_repo.join(".landmark/run/evidence.json");
     let internal_evidence: Value =
         serde_json::from_str(&fs::read_to_string(&internal_evidence_path)?)?;
-    release_kit::assert_contract(&internal_evidence["release_kit"], "internal release kit")?;
+    release_kit_contract::assert_contract(
+        &internal_evidence["release_kit"],
+        "internal release kit",
+    )?;
     let internal_artifacts = internal_evidence["release_kit"]["artifacts"]
         .as_array()
         .ok_or("internal release kit artifacts missing")?;


### PR DESCRIPTION
## Summary
Splits `release_kit.rs`'s self-contained JSON-schema contract validation (`assert_contract` and its supporting validators, ~350 lines) into its own module, `release_kit_contract.rs`. This is what backlog 012 asked for before adding tests: `release_kit.rs` was at 1012 lines under #177's deliberate, explicitly-reasoned ratchet bump to 1050; growing it further without splitting would have hit that cap again immediately. `release_kit.rs` is now 666 lines and `bin/check-architecture`'s cap reverts to 1000 — headroom restored, not spent.

Adds `release_kit_tests.rs` (mirroring the existing `version_decision_tests.rs` pattern) with direct unit tests for:
- `release_kit_importance` — every branch: security, migration (via major bump/breaking/migration_heavy), high, launch, low, and the medium default — plus the launch/medium boundary case where a bootstrap release has no bump signal.
- `release_kit_needs_rich_artifacts` — every importance value.
- `release_kit_audiences` — `release-operator`/`docs-owner` gated correctly on rich-artifact need, primary + `developer-operator` always present.

These were bare private `fn`; bumped to `pub(crate)` so the sibling test file can reach them, matching how `version_decision.rs`'s `classify_commit`/`decide_version` are exposed for the same reason.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked` (75 tests, 10 new) all green
- [x] `cargo run --locked -- replay-action` — all 25 scenarios pass (confirms the module split didn't break the `release_kit::assert_contract` → `release_kit_contract::assert_contract` call-site rename)
- [x] `check-action-contract`, `check-version-sync`, `bin/check-architecture`, `actionlint`, `git diff --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)