### PR TITLE
feat(schema): tighten release-context classification/cost, add drift check

### DIFF
--- a/backlog.d/_done/013-tighten-release-context-classification-schema.md
+++ b/backlog.d/_done/013-tighten-release-context-classification-schema.md
@@ -1,6 +1,6 @@
 # Tighten release-context.v1.schema.json's classification/cost objects and add drift detection
 
-Priority: P1 · Status: ready · Estimate: M
+Priority: P1 · Status: done · Estimate: M
 
 ## Goal
 `schemas/release-context.v1.schema.json`'s `classification` and `cost`
@@ -13,20 +13,39 @@ drift check so the schema can't silently fall out of sync with the struct
 again, following the pattern the repo already uses for the manifest schema.
 
 ## Oracle
-- [ ] `schemas/release-context.v1.schema.json`'s `classification` property
+- [x] `schemas/release-context.v1.schema.json`'s `classification` property
       lists `categories`, `significance`, `user_visible`, `breaking`,
       `security`, `migration_heavy`, `source`, `model`,
       `deterministic_signals`, `disagreements`, `reasons` with correct types.
-- [ ] `schemas/release-context.v1.schema.json`'s `cost` property lists
+- [x] `schemas/release-context.v1.schema.json`'s `cost` property lists
       `input_tokens`, `output_tokens`, `model_tier`, `model`, `estimated_usd`,
       `skip`, `skip_reason` with correct types.
-- [ ] A key-set drift check exists for both objects, added to
+- [x] A key-set drift check exists for both objects, added to
       `manifest_schema_key_contracts()`-style table (or a sibling function)
       and wired into `validate_agent_native_contracts`
       (`crates/landmark/src/release_ops/contracts.rs:186`), so
       `bin/check-action-contract` fails if the schema's declared keys and the
       Rust struct's serialized field names diverge.
-- [ ] `bin/gate` passes.
+- [x] `bin/gate` passes.
+
+## Evidence
+- Generalized `validate_manifest_schema_alignment(path)` into
+  `validate_schema_key_alignment(path, contracts)` (contracts now passed in,
+  not hardcoded), and added `release_context_schema_key_contracts()` in
+  `manifest.rs` alongside its manifest sibling. Wired both the manifest and
+  new release-context checks into `validate_agent_native_contracts`.
+- Both `classification` and `cost` also got `additionalProperties: false`,
+  matching the convention already used throughout
+  `landmark-manifest.v1.schema.json` and the `version_decision` object added
+  to `run-evidence.v1.schema.json` earlier tonight — the top-level
+  `release-context.v1.schema.json` stays deliberately loose
+  (`additionalProperties: true`), only these two high-stakes sub-objects
+  tightened.
+- Verified the drift check is a real, non-tautological guard: temporarily
+  deleted `disagreements` from the schema's `classification.properties` and
+  `required` list and confirmed `check-action-contract` fails with
+  `release-context.classification schema keys drifted from runtime
+  validation: expected {...11 keys...}, got {...10 keys...}`, then restored.
 
 ## Notes
 Verified live: `schemas/release-context.v1.schema.json`'s `classification` and

--- a/crates/landmark/src/manifest.rs
+++ b/crates/landmark/src/manifest.rs
@@ -464,6 +464,42 @@ pub(crate) fn manifest_schema_key_contracts()
     ]
 }
 
+pub(crate) fn release_context_schema_key_contracts()
+-> Vec<(&'static str, &'static str, &'static [&'static str])> {
+    vec![
+        (
+            "release-context.classification",
+            "/properties/classification/properties",
+            &[
+                "categories",
+                "significance",
+                "user_visible",
+                "breaking",
+                "security",
+                "migration_heavy",
+                "source",
+                "model",
+                "deterministic_signals",
+                "disagreements",
+                "reasons",
+            ],
+        ),
+        (
+            "release-context.cost",
+            "/properties/cost/properties",
+            &[
+                "input_tokens",
+                "output_tokens",
+                "model_tier",
+                "model",
+                "estimated_usd",
+                "skip",
+                "skip_reason",
+            ],
+        ),
+    ]
+}
+
 pub(crate) fn yaml_value_at_label<'a>(
     raw: &'a serde_yaml::Value,
     label: &str,

--- a/crates/landmark/src/release_ops/contracts.rs
+++ b/crates/landmark/src/release_ops/contracts.rs
@@ -223,8 +223,13 @@ pub(crate) fn validate_agent_native_contracts(repo_root: &Path) -> Result<Vec<St
         }
     }
     errors.extend(validate_command_contract_coverage());
-    errors.extend(validate_manifest_schema_alignment(
+    errors.extend(validate_schema_key_alignment(
         &repo_root.join("schemas/landmark-manifest.v1.schema.json"),
+        manifest_schema_key_contracts(),
+    )?);
+    errors.extend(validate_schema_key_alignment(
+        &repo_root.join("schemas/release-context.v1.schema.json"),
+        release_context_schema_key_contracts(),
     )?);
     for required in [
         "landmark describe --json",
@@ -436,10 +441,13 @@ pub(crate) fn validate_readme_command_names(readme: &str) -> Vec<String> {
     errors
 }
 
-pub(crate) fn validate_manifest_schema_alignment(path: &Path) -> Result<Vec<String>> {
+pub(crate) fn validate_schema_key_alignment(
+    path: &Path,
+    contracts: Vec<(&'static str, &'static str, &'static [&'static str])>,
+) -> Result<Vec<String>> {
     let schema: Value = serde_json::from_str(&fs::read_to_string(path)?)?;
     let mut errors = Vec::new();
-    for (label, pointer, allowed) in manifest_schema_key_contracts() {
+    for (label, pointer, allowed) in contracts {
         let actual = schema_property_keys(&schema, pointer);
         let expected: BTreeSet<String> = allowed.iter().map(|key| (*key).to_string()).collect();
         if actual != expected {

--- a/schemas/release-context.v1.schema.json
+++ b/schemas/release-context.v1.schema.json
@@ -27,8 +27,38 @@
       }
     },
     "sources": { "type": "array", "items": { "type": "object" } },
-    "classification": { "type": "object" },
-    "cost": { "type": "object" },
+    "classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["categories", "significance", "user_visible", "breaking", "security", "migration_heavy", "source", "model", "deterministic_signals", "disagreements", "reasons"],
+      "properties": {
+        "categories": { "type": "array", "items": { "type": "string" } },
+        "significance": { "type": "string" },
+        "user_visible": { "type": "boolean" },
+        "breaking": { "type": "boolean" },
+        "security": { "type": "boolean" },
+        "migration_heavy": { "type": "boolean" },
+        "source": { "type": "string" },
+        "model": { "type": "string" },
+        "deterministic_signals": { "type": "array", "items": { "type": "string" } },
+        "disagreements": { "type": "array", "items": { "type": "string" } },
+        "reasons": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_tokens", "output_tokens", "model_tier", "model", "estimated_usd", "skip", "skip_reason"],
+      "properties": {
+        "input_tokens": { "type": "integer", "minimum": 0 },
+        "output_tokens": { "type": "integer", "minimum": 0 },
+        "model_tier": { "type": "string" },
+        "model": { "type": "string" },
+        "estimated_usd": { "type": "number" },
+        "skip": { "type": "boolean" },
+        "skip_reason": { "type": "string" }
+      }
+    },
     "decision": { "type": "object", "required": ["action", "reason", "llm_required", "model_tier"] }
   }
 }


### PR DESCRIPTION
## Summary
`schemas/release-context.v1.schema.json`'s `classification` and `cost` sub-objects were bare `{"type": "object"}` with no `properties`, even though `ReleaseClassification`/`CostEstimate` (the Rust structs they describe) are stable and richer — including `deterministic_signals` and `disagreements`, the exact fields an agent reading the disagreement alarm needs. Added real `properties`/`required` (with `additionalProperties: false`, matching the convention already used in `landmark-manifest.v1.schema.json`) to both.

Generalized `validate_manifest_schema_alignment(path)` into `validate_schema_key_alignment(path, contracts)` — contracts now passed in rather than hardcoded to the manifest table — and added `release_context_schema_key_contracts()` alongside its manifest sibling, wired into `validate_agent_native_contracts` so `check-action-contract` fails if the schema's declared keys and the struct's actual fields diverge.

Verified the drift check is a real guard, not tautological: temporarily deleted `disagreements` from the schema and confirmed `check-action-contract` failed with a clear diff (`expected {...11 keys...}, got {...10 keys...}`) before restoring it.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked` (75 tests) all green
- [x] `cargo run --locked -- check-action-contract`, `replay-action` (25 scenarios), `bin/check-architecture`, `check-version-sync`, `actionlint`, `git diff --check` all pass
- [x] Confirmed the drift check catches a real regression (see commit message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)