### PR TITLE
test(errors): cover the remaining classify_failure branches

### DIFF
--- a/backlog.d/_done/015-cover-remaining-failure-classification-branches.md
+++ b/backlog.d/_done/015-cover-remaining-failure-classification-branches.md
@@ -1,6 +1,6 @@
 # Cover the remaining classify_failure branches with tests
 
-Priority: P2 · Status: ready · Estimate: S
+Priority: P2 · Status: done · Estimate: S
 
 ## Goal
 `classify_failure` (`crates/landmark/src/errors.rs:26-104`) is the function
@@ -10,7 +10,7 @@ behind every `--error-format json` failure envelope's `code`/`stage`/
 have a pinned test today.
 
 ## Oracle
-- [ ] A test exists for each remaining branch of `classify_failure`:
+- [x] A test exists for each remaining branch of `classify_failure`:
       `provider_outage` (429/rate-limit/timeout), `budget_skip`
       (budget/model.policy=off), `synthesis_degradation`
       (degraded/quality), `publication_mutation_failure` (release
@@ -18,10 +18,21 @@ have a pinned test today.
       `artifact_write_failure` (write/file/permission), `invalid_input`
       (unsupported provider/requires/must), and the `command_failed`
       catch-all for a message matching none of the above.
-- [ ] Each test asserts `code`, `stage`, and `retryable` (not just that a
+- [x] Each test asserts `code`, `stage`, and `retryable` (not just that a
       match occurred) so silent branch reordering or overlap regressions get
       caught.
-- [ ] `cargo test --locked` and `bin/gate` pass.
+- [x] `cargo test --locked` and `bin/gate` pass.
+
+## Evidence
+`failure_classifier_covers_remaining_branches` (`crates/landmark/src/tests.rs`)
+adds all 8 remaining cases. Each message was hand-traced against every
+earlier branch's trigger substrings to make sure it hits only its intended
+branch (documented inline: the function is an order-sensitive first-match
+if/else-if chain, e.g. `"could not update the release body"` must avoid
+`"auth"`/`"github-token"`/`"429"`/`"budget"`/`"degraded"` etc. to actually land
+on `publication_mutation_failure` instead of an earlier branch). All 10 cases
+(2 pre-existing + 7 new named branches + the `command_failed` catch-all)
+passed on the first run, confirming the trace was correct.
 
 ## Notes
 Verified live: `grep -rn "classify_failure" crates/landmark/src` shows only

--- a/crates/landmark/src/tests.rs
+++ b/crates/landmark/src/tests.rs
@@ -842,6 +842,62 @@ fn failure_classifier_emits_stable_codes_and_redacts_tokens() {
     assert!(redacted.contains("[REDACTED]"));
 }
 
+/// classify_failure is a first-match if/else-if chain over substring checks,
+/// so branch order matters: an added or reordered branch could silently
+/// steal matches from another branch without any test failing unless every
+/// branch has a message that hits it and only it. Each message below is
+/// chosen to avoid every earlier branch's trigger words.
+#[test]
+fn failure_classifier_covers_remaining_branches() {
+    let provider_outage = classify_failure("HTTP 429 too many requests from provider");
+    assert_eq!(provider_outage.code, "provider_outage");
+    assert_eq!(provider_outage.stage, "provider");
+    assert!(provider_outage.retryable);
+
+    let budget_skip = classify_failure("synthesis skipped: budget exceeded for this release");
+    assert_eq!(budget_skip.code, "budget_skip");
+    assert_eq!(budget_skip.stage, "synthesis");
+    assert!(!budget_skip.retryable);
+
+    let synthesis_degradation =
+        classify_failure("synthesis quality degraded; using unvalidated output");
+    assert_eq!(synthesis_degradation.code, "synthesis_degradation");
+    assert_eq!(synthesis_degradation.stage, "synthesis");
+    assert!(!synthesis_degradation.retryable);
+
+    let publication_mutation_failure =
+        classify_failure("landmark could not update the release body; release remains published");
+    assert_eq!(
+        publication_mutation_failure.code,
+        "publication_mutation_failure"
+    );
+    assert_eq!(publication_mutation_failure.stage, "publication");
+    assert!(publication_mutation_failure.retryable);
+
+    let feed_failure = classify_failure("could not update the rss release feed");
+    assert_eq!(feed_failure.code, "feed_failure");
+    assert_eq!(feed_failure.stage, "artifact");
+    assert!(!feed_failure.retryable);
+
+    let artifact_write_failure =
+        classify_failure("failed to write technical changelog output: permission denied");
+    assert_eq!(artifact_write_failure.code, "artifact_write_failure");
+    assert_eq!(artifact_write_failure.stage, "artifact");
+    assert!(!artifact_write_failure.retryable);
+
+    let invalid_input = classify_failure(
+        "unsupported provider 'foo'; this build supports provider=local or provider=github",
+    );
+    assert_eq!(invalid_input.code, "invalid_input");
+    assert_eq!(invalid_input.stage, "configuration");
+    assert!(!invalid_input.retryable);
+
+    let command_failed = classify_failure("unexpected git subprocess exit status 128");
+    assert_eq!(command_failed.code, "command_failed");
+    assert_eq!(command_failed.stage, "runtime");
+    assert!(!command_failed.retryable);
+}
+
 fn test_synthesis_config(
     model_policy: &str,
     max_input_tokens: Option<u64>,


### PR DESCRIPTION
## Summary
`classify_failure` decides the `code`/`stage`/`retryable`/`user_action` of every `--error-format json` failure envelope — an agent-native contract `docs/agent-integration.md` documents directly. Only 2 of its 10 branches (`provider_auth`, `invalid_changelog_source`) had a pinned test.

Added the other 8: `provider_outage`, `budget_skip`, `synthesis_degradation`, `publication_mutation_failure`, `feed_failure`, `artifact_write_failure`, `invalid_input`, and the `command_failed` catch-all. Each asserts `code`/`stage`/`retryable`, not just that a match occurred.

The function is an order-sensitive first-match if/else-if chain over substring checks, so each test message was hand-traced against every earlier branch's trigger words to confirm it lands on its intended branch and no other — exactly the class of regression (an added or reordered branch silently stealing another's matches) this ticket exists to catch. All 10 cases passed on the first run.

## Test plan
- [x] `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked` (76 tests, 1 new) all green
- [x] `check-action-contract`, `replay-action` (25 scenarios), `bin/check-architecture`, `check-version-sync`, `actionlint`, `git diff --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)