### PR TITLE
fix(release-kit): scope extract-prs to the release's tag range

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -407,6 +407,7 @@ runs:
             --repository "${GITHUB_REPOSITORY}" \
             --release-tag "${release_tag}" \
             --output-file "${target_file}" \
+            --repo-root "${GITHUB_WORKSPACE}" \
             > /dev/null \
             2> "${RUNNER_TEMP}/landmark-extract-prs.log"
         }

--- a/crates/landmark/src/cli.rs
+++ b/crates/landmark/src/cli.rs
@@ -141,6 +141,9 @@ pub(crate) struct ExtractPrsArgs {
     pub(crate) output_file: PathBuf,
     #[arg(long = "api-base-url", default_value = "https://api.github.com")]
     pub(crate) api_base_url: String,
+    /// Path to the local git checkout used to scope PRs to the release's tag range
+    #[arg(long = "repo-root", default_value = ".")]
+    pub(crate) repo_root: PathBuf,
 }
 
 #[derive(Args)]

--- a/crates/landmark/src/extract_prs_tests.rs
+++ b/crates/landmark/src/extract_prs_tests.rs
@@ -1,0 +1,69 @@
+use super::*;
+
+fn pr(number: i64, title: &str, merged_at: Option<&str>) -> Value {
+    json!({
+        "number": number,
+        "title": title,
+        "user": {"login": "octocat"},
+        "merged_at": merged_at,
+    })
+}
+
+#[test]
+fn filter_prs_by_range_excludes_out_of_range_merges() {
+    let since = DateTime::parse_from_rfc3339("2024-01-10T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let until = DateTime::parse_from_rfc3339("2024-02-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let prs = vec![
+        pr(1, "ancient unrelated feature", Some("2023-11-01T00:00:00Z")),
+        pr(2, "in range fix", Some("2024-01-15T00:00:00Z")),
+        pr(3, "future unrelated feature", Some("2024-03-01T00:00:00Z")),
+        pr(4, "still open", None),
+    ];
+
+    let filtered = filter_prs_by_range(&prs, Some(since), Some(until));
+
+    let titles: Vec<_> = filtered
+        .iter()
+        .map(|pr| pr["title"].as_str().unwrap())
+        .collect();
+    assert_eq!(titles, vec!["in range fix"]);
+}
+
+#[test]
+fn filter_prs_by_range_with_no_previous_tag_is_unbounded_below() {
+    let until = DateTime::parse_from_rfc3339("2024-02-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let prs = vec![
+        pr(1, "first ever release commit", Some("2020-01-01T00:00:00Z")),
+        pr(2, "still too new", Some("2024-03-01T00:00:00Z")),
+    ];
+
+    let filtered = filter_prs_by_range(&prs, None, Some(until));
+
+    let titles: Vec<_> = filtered
+        .iter()
+        .map(|pr| pr["title"].as_str().unwrap())
+        .collect();
+    assert_eq!(titles, vec!["first ever release commit"]);
+}
+
+#[test]
+fn git_commit_date_reads_tag_commit_and_none_for_missing_tag() {
+    let repo = tempfile::tempdir().unwrap();
+    init_fixture_repo(repo.path(), "v1.0.0").unwrap();
+
+    assert!(git_commit_date(repo.path(), "v1.0.0").is_some());
+    assert!(git_commit_date(repo.path(), "v9.9.9-does-not-exist").is_none());
+}
+
+// The end-to-end regression pinning "extract-prs must not leak closed PRs outside
+// the release's tag range" lives in the replay harness as
+// `scenario_extract_prs_scoped_to_release_range` (replay/provider_scenarios), since
+// it needs to exercise `extract-prs` as a real subprocess against a fake GitHub
+// server, which only works via `landmark replay-action`, not `cargo test`'s
+// harness binary.

--- a/crates/landmark/src/main.rs
+++ b/crates/landmark/src/main.rs
@@ -1,4 +1,4 @@
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use hmac::{Hmac, Mac};
 use pulldown_cmark::{Options, Parser as MarkdownParser, html};
@@ -24,7 +24,10 @@ mod classification_tests;
 mod cli;
 mod describe;
 mod errors;
+#[cfg(test)]
+mod extract_prs_tests;
 mod manifest;
+mod pr_range;
 mod providers;
 mod release_classification;
 mod release_kit;
@@ -47,6 +50,7 @@ pub(crate) use cli::*;
 pub(crate) use describe::*;
 pub(crate) use errors::*;
 pub(crate) use manifest::*;
+pub(crate) use pr_range::*;
 pub(crate) use providers::*;
 pub(crate) use release_classification::*;
 pub(crate) use release_ops::*;

--- a/crates/landmark/src/pr_range.rs
+++ b/crates/landmark/src/pr_range.rs
@@ -1,0 +1,41 @@
+use crate::*;
+
+/// Committer date of `rev` in the local checkout, or `None` if `rev` cannot be
+/// resolved (e.g. a tag that doesn't exist locally yet).
+pub(crate) fn git_commit_date(repo_root: &Path, rev: &str) -> Option<DateTime<Utc>> {
+    let output = run_ok("git", ["log", "-1", "--format=%cI", rev], repo_root).ok()?;
+    let trimmed = output.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    DateTime::parse_from_rfc3339(trimmed)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
+}
+
+pub(crate) fn pr_merged_at(pr: &Value) -> Option<DateTime<Utc>> {
+    pr["merged_at"]
+        .as_str()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
+}
+
+/// Keeps only PRs merged after `since` (exclusive) and at or before `until`
+/// (inclusive). A `None` bound is unbounded on that side. PRs with no
+/// `merged_at` (still open, or closed unmerged) are dropped.
+pub(crate) fn filter_prs_by_range(
+    prs: &[Value],
+    since: Option<DateTime<Utc>>,
+    until: Option<DateTime<Utc>>,
+) -> Vec<Value> {
+    prs.iter()
+        .filter(|pr| {
+            let Some(merged_at) = pr_merged_at(pr) else {
+                return false;
+            };
+            since.is_none_or(|bound| merged_at > bound)
+                && until.is_none_or(|bound| merged_at <= bound)
+        })
+        .cloned()
+        .collect()
+}

--- a/crates/landmark/src/replay/contract_scenarios.rs
+++ b/crates/landmark/src/replay/contract_scenarios.rs
@@ -158,7 +158,13 @@ pub(crate) fn action_subcommand_replay_coverage() -> BTreeMap<&'static str, Vec<
         ("healthcheck", vec!["http_resilience_policy"]),
         ("preflight-tags", vec!["action_side_effect_coverage"]),
         ("fetch-release-body", vec!["consumer_full_mode_success"]),
-        ("extract-prs", vec!["consumer_full_mode_success"]),
+        (
+            "extract-prs",
+            vec![
+                "consumer_full_mode_success",
+                "extract_prs_scoped_to_release_range",
+            ],
+        ),
         (
             "synthesize",
             vec!["synthesis_cost_policy", "consumer_synthesis_only_success"],

--- a/crates/landmark/src/replay/fake_server.rs
+++ b/crates/landmark/src/replay/fake_server.rs
@@ -36,6 +36,9 @@ pub(crate) fn start_fake_server(mut state: FakeState) -> Result<FakeServer> {
                         json_response(200, json!({"choices": [{"message": {"content": notes}}]}))
                     }
                 }
+                (Method::Get, url) if url.contains("/pulls") => {
+                    json_response(200, Value::Array(state.pull_requests.clone()))
+                }
                 (Method::Get, url) if url.contains("/releases/tags/") => {
                     let tag = url.rsplit("/releases/tags/").next().unwrap();
                     let tag = urlencoding::decode(tag).unwrap_or_default().to_string();

--- a/crates/landmark/src/replay/mod.rs
+++ b/crates/landmark/src/replay/mod.rs
@@ -164,6 +164,10 @@ pub(crate) fn scenario_map() -> BTreeMap<String, Scenario> {
         scenario_synthesis_cost_policy,
     );
     map.insert(
+        "extract_prs_scoped_to_release_range".to_string(),
+        scenario_extract_prs_scoped_to_release_range,
+    );
+    map.insert(
         "backfill_release_history".to_string(),
         scenario_backfill_release_history,
     );
@@ -224,6 +228,7 @@ pub(crate) fn canonical_scenarios() -> Vec<&'static str> {
         "consumer_synthesis_only_success",
         "self_release_pr_path",
         "synthesis_cost_policy",
+        "extract_prs_scoped_to_release_range",
         "backfill_release_history",
         "publication_degraded_optional",
         "publication_degraded_required",

--- a/crates/landmark/src/replay/provider_scenarios/mod.rs
+++ b/crates/landmark/src/replay/provider_scenarios/mod.rs
@@ -1,12 +1,14 @@
 use crate::*;
 mod consumers;
 mod failures;
+mod pr_scoping;
 mod provider_runs;
 mod self_release;
 mod synthesis_cost;
 
 pub(crate) use consumers::*;
 pub(crate) use failures::*;
+pub(crate) use pr_scoping::*;
 pub(crate) use provider_runs::*;
 pub(crate) use self_release::*;
 pub(crate) use synthesis_cost::*;
@@ -19,4 +21,5 @@ pub(crate) struct FakeState {
     pub(crate) update_status: u16,
     pub(crate) releases: BTreeMap<String, Value>,
     pub(crate) requests: Vec<Value>,
+    pub(crate) pull_requests: Vec<Value>,
 }

--- a/crates/landmark/src/replay/provider_scenarios/pr_scoping.rs
+++ b/crates/landmark/src/replay/provider_scenarios/pr_scoping.rs
@@ -1,0 +1,105 @@
+use crate::*;
+
+fn scoping_pr(number: i64, title: &str, merged_at: Option<&str>) -> Value {
+    json!({
+        "number": number,
+        "title": title,
+        "user": {"login": "octocat"},
+        "merged_at": merged_at,
+    })
+}
+
+/// Commits with an explicit, far-future author/committer date so the gap between
+/// the fixture's two tags is large and stable, independent of how fast the two
+/// `git commit` calls run back-to-back on the test host.
+fn commit_with_date(repo: &Path, message: &str, date: &str) -> Result<()> {
+    let status = Command::new("git")
+        .args(["commit", "-q", "-m", message])
+        .current_dir(repo)
+        .env("GIT_AUTHOR_DATE", date)
+        .env("GIT_COMMITTER_DATE", date)
+        .status()?;
+    if !status.success() {
+        return Err(format!("git commit failed for {message}").into());
+    }
+    Ok(())
+}
+
+/// Regression for the bitterblossom v1.79.0 incident: with no CHANGELOG.md,
+/// `extract-prs` fell back to GitHub's "last 100 closed PRs" unfiltered, so a
+/// release with one real commit shipped notes describing ~19 unrelated features.
+/// `extract-prs` must scope PRs to the release's tag range instead.
+pub(crate) fn scenario_extract_prs_scoped_to_release_range(tmp_root: &Path) -> Result<Value> {
+    let repo = tmp_root.join("extract-prs-scoped-to-release-range");
+    init_fixture_repo(&repo, "v1.0.0")?;
+    fs::write(repo.join("feature.txt"), "second release\n")?;
+    run_ok("git", ["add", "feature.txt"], &repo)?;
+    commit_with_date(&repo, "feat: second release", "2030-06-01T00:00:00+00:00")?;
+    run_ok("git", ["tag", "v1.1.0"], &repo)?;
+
+    let previous = git_commit_date(&repo, "v1.0.0").ok_or("missing v1.0.0 commit date")?;
+    let target = git_commit_date(&repo, "v1.1.0").ok_or("missing v1.1.0 commit date")?;
+
+    let fake = FakeState {
+        pull_requests: vec![
+            scoping_pr(
+                1,
+                "ancient unrelated feature",
+                Some(&(previous - chrono::Duration::days(30)).to_rfc3339()),
+            ),
+            scoping_pr(
+                2,
+                "the actual shipped fix",
+                Some(&(previous + chrono::Duration::hours(1)).to_rfc3339()),
+            ),
+            scoping_pr(
+                3,
+                "merged after this release",
+                Some(&(target + chrono::Duration::days(1)).to_rfc3339()),
+            ),
+            scoping_pr(4, "still open, never merged", None),
+        ],
+        ..Default::default()
+    };
+    let server = start_fake_server(fake)?;
+
+    let output_file = repo.join("pr-changelog.md");
+    let result = Command::new(current_exe())
+        .args([
+            "extract-prs",
+            "--github-token",
+            "token",
+            "--repository",
+            "owner/repo",
+            "--release-tag",
+            "v1.1.0",
+            "--api-base-url",
+            &server.url,
+            "--repo-root",
+        ])
+        .arg(&repo)
+        .args(["--output-file"])
+        .arg(&output_file)
+        .output()?;
+    if !result.status.success() {
+        return Err(String::from_utf8_lossy(&result.stderr).to_string().into());
+    }
+    let rendered = fs::read_to_string(&output_file)?;
+    if !rendered.contains("the actual shipped fix") {
+        return Err(format!("expected in-range PR in rendered changelog:\n{rendered}").into());
+    }
+    if rendered.contains("ancient unrelated feature") {
+        return Err(format!("out-of-range PR leaked into rendered changelog:\n{rendered}").into());
+    }
+    if rendered.contains("merged after this release") {
+        return Err(format!("future PR leaked into rendered changelog:\n{rendered}").into());
+    }
+    if rendered.contains("still open, never merged") {
+        return Err(format!("unmerged PR leaked into rendered changelog:\n{rendered}").into());
+    }
+
+    Ok(json!({
+        "output_file": output_file,
+        "rendered_pr_count": rendered.lines().filter(|line| line.starts_with("- ")).count(),
+    }))
+}

--- a/crates/landmark/src/synthesis.rs
+++ b/crates/landmark/src/synthesis.rs
@@ -75,9 +75,17 @@ pub(crate) fn fetch_release_body(args: FetchReleaseBodyArgs) -> Result<()> {
 
 pub(crate) fn extract_prs(args: ExtractPrsArgs) -> Result<()> {
     let provider = GitHubProvider::required(&args.api_base_url, &args.github_token);
+    let (previous_tag, target_tag) = context_git_range(&args.repo_root, &args.release_tag);
+    let since = if previous_tag.is_empty() {
+        None
+    } else {
+        git_commit_date(&args.repo_root, &previous_tag)
+    };
+    let until = git_commit_date(&args.repo_root, &target_tag);
     let prs = provider.closed_pull_requests(&args.repository)?;
+    let scoped = filter_prs_by_range(&prs, since, until);
     let mut rendered = String::new();
-    for pr in prs.iter().filter(|pr| !pr["merged_at"].is_null()) {
+    for pr in &scoped {
         let number = pr["number"].as_i64().unwrap_or_default();
         let title = pr["title"].as_str().unwrap_or("Untitled");
         let user = pr["user"]["login"].as_str().unwrap_or("unknown");


### PR DESCRIPTION
## Summary
- `extract-prs` fetched GitHub's last 100 closed PRs with no date/tag/merge-range filter. When a repo has no `CHANGELOG.md` (bitterblossom), that unfiltered page became "ground truth" for synthesis, and unrelated PRs leaked into release notes — bitterblossom v1.79.0 shipped notes describing ~19 unrelated features for a one-commit release.
- `extract-prs` now scopes fetched PRs to `(previous_tag, target_tag]` using the same `context_git_range()` the deterministic classifier already trusts (via each tag's local git commit date), and drops anything outside that window before rendering.
- Source: `~/.factory-lanes/wave1/landmark-model-audit.md`, finding #1 (P0).

## Test plan
- [x] New regression test: `filter_prs_by_range` unit tests + `git_commit_date` unit test (`crates/landmark/src/extract_prs_tests.rs`)
- [x] New replay-harness regression `extract_prs_scoped_to_release_range` (`crates/landmark/src/replay/provider_scenarios/pr_scoping.rs`) — a fixture repo with two tags, a fake GitHub server returning closed PRs both inside and outside the range, asserts out-of-range/unmerged PRs never reach the rendered PR changelog while the in-range PR does
- [x] `bin/gate` green (fmt, clippy, `cargo test`, `check-version-sync`, `check-action-contract`, `setup`, `replay-action` — 26/26 canonical scenarios pass, linux build check skipped on macOS host per script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)