### PR TITLE
fix(release-kit): stop synthesizing from the wrong changelog section

### DIFF
--- a/crates/landmark/src/main.rs
+++ b/crates/landmark/src/main.rs
@@ -37,6 +37,8 @@ mod self_release;
 mod setup_fleet;
 mod synthesis;
 #[cfg(test)]
+mod synthesis_tests;
+#[cfg(test)]
 mod tests;
 mod util;
 mod version_decision;

--- a/crates/landmark/src/replay/provider_scenarios/synthesis_cost.rs
+++ b/crates/landmark/src/replay/provider_scenarios/synthesis_cost.rs
@@ -224,6 +224,10 @@ model:
     - fallback/model
 "#,
     )?;
+    fs::write(
+        repo.join("CHANGELOG.md"),
+        "## [1.2.3]\n\n- feat(cli): add a fleet command\n",
+    )?;
     let mut fallback_fake = FakeState {
         llm_status: 200,
         llm_notes: VALID_NOTES.to_string(),

--- a/crates/landmark/src/synthesis.rs
+++ b/crates/landmark/src/synthesis.rs
@@ -287,7 +287,7 @@ pub(crate) fn resolve_technical_changelog(
         if text.trim().is_empty() {
             None
         } else {
-            Some(extract_release_section(&text, &args.version))
+            extract_release_section(&text, &args.version)
         }
     } else {
         None
@@ -299,7 +299,13 @@ pub(crate) fn resolve_technical_changelog(
             .or(from_release_body)
             .or(from_prs)
             .ok_or_else(|| "no changelog source found".into()),
-        "changelog" => from_changelog.ok_or_else(|| "CHANGELOG.md is missing or empty".into()),
+        "changelog" => from_changelog.ok_or_else(|| {
+            format!(
+                "CHANGELOG.md is missing, empty, or has no section for {}",
+                args.version
+            )
+            .into()
+        }),
         "release-body" => {
             from_release_body.ok_or_else(|| "release body source is missing or empty".into())
         }
@@ -320,14 +326,11 @@ pub(crate) fn read_optional_file(path: &Path) -> Result<Option<String>> {
     }
 }
 
-pub(crate) fn extract_release_section(text: &str, version: &str) -> String {
+pub(crate) fn extract_release_section(text: &str, version: &str) -> Option<String> {
     let normalized =
         normalize_version(version).unwrap_or_else(|_| version.trim_start_matches('v').to_string());
     let heading = Regex::new(r"(?m)^##\s+\[?v?([0-9]+\.[0-9]+\.[0-9][^\]\s]*)\]?.*$").unwrap();
     let matches: Vec<_> = heading.find_iter(text).collect();
-    if matches.is_empty() {
-        return text.to_string();
-    }
     for (index, mat) in matches.iter().enumerate() {
         let line = text[mat.start()..mat.end()].to_string();
         if line.contains(&normalized) || line.contains(version) {
@@ -335,15 +338,14 @@ pub(crate) fn extract_release_section(text: &str, version: &str) -> String {
                 .get(index + 1)
                 .map(|next| next.start())
                 .unwrap_or(text.len());
-            return text[mat.start()..end].trim().to_string();
+            return Some(text[mat.start()..end].trim().to_string());
         }
     }
-    let first = matches[0];
-    let end = matches
-        .get(1)
-        .map(|next| next.start())
-        .unwrap_or(text.len());
-    text[first.start()..end].trim().to_string()
+    // No heading matches this release. Silently returning the first (most recent)
+    // section here used to hand the model a stale, unrelated changelog as ground
+    // truth for the release actually being synthesized — return None instead and
+    // let the caller fail loudly or fall back to a different source.
+    None
 }
 
 pub(crate) fn render_prompt(
@@ -921,7 +923,7 @@ pub(crate) fn notes_with_classification_notice(
         classification.deterministic_signals.join(", ")
     };
     format!(
-        "{}\n\n> Landmark classification notice: deterministic release signals ({signals}) disagreed with model classification; synthesis proceeded. {}",
+        "{}\n\n<details>\n<summary>Release classification notes</summary>\n\nLandmark classification notice: deterministic release signals ({signals}) disagreed with model classification; synthesis proceeded. {}\n\n</details>",
         notes.trim(),
         classification.disagreements.join("; ")
     )

--- a/crates/landmark/src/synthesis_tests.rs
+++ b/crates/landmark/src/synthesis_tests.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+const STALE_CHANGELOG: &str =
+    "## [1.4.2]\n\n- fix: stale unrelated bugfix\n\n## [1.3.0]\n\n- feat: older feature\n";
+
+#[test]
+fn extract_release_section_returns_none_when_version_heading_is_missing() {
+    // Regression: canary's CHANGELOG.md topped out at 1.4.2 while 1.6.0/1.7.0 were
+    // being synthesized. The old behavior silently returned matches[0] (the 1.4.2
+    // section) as if it were the 1.6.0 release, feeding the model a stale, unrelated
+    // changelog it faithfully turned into confidently wrong release notes.
+    let section = extract_release_section(STALE_CHANGELOG, "1.6.0");
+
+    assert_eq!(section, None);
+}
+
+#[test]
+fn extract_release_section_finds_the_matching_heading() {
+    let section = extract_release_section(STALE_CHANGELOG, "1.4.2").expect("section found");
+
+    assert!(section.contains("stale unrelated bugfix"));
+    assert!(!section.contains("older feature"));
+}
+
+#[test]
+fn extract_release_section_returns_none_when_text_has_no_headings_at_all() {
+    let section = extract_release_section("just some prose, no version headings\n", "1.6.0");
+
+    assert_eq!(section, None);
+}
+
+fn synthesize_args_with_repo(repo: &Path, version: &str) -> SynthesizeArgs {
+    SynthesizeArgs {
+        api_key: "test".into(),
+        model: String::new(),
+        model_policy: String::new(),
+        api_url: "http://example.invalid".into(),
+        fallback_models: String::new(),
+        product_name: "Landmark".into(),
+        product_description: String::new(),
+        voice_guide: String::new(),
+        audience: None,
+        changelog_source: None,
+        version: version.into(),
+        changelog_file: repo.join("CHANGELOG.md"),
+        release_body_file: repo.join("release-body.md"),
+        pr_changelog_file: repo.join("pr-changelog.md"),
+        prompt_template: PathBuf::from("."),
+        quality_file: repo.join("quality.txt"),
+        attempts_file: PathBuf::from("."),
+        templates_dir: PathBuf::from("templates/prompts"),
+        repo_root: repo.to_path_buf(),
+        dry_run_cost: false,
+        context_metadata_file: PathBuf::from("."),
+    }
+}
+
+fn test_synthesis_config() -> EffectiveSynthesisConfig {
+    EffectiveSynthesisConfig {
+        product_name: "Demo".into(),
+        product_description: String::new(),
+        voice_guide: String::new(),
+        audience: "developer".into(),
+        changelog_source: "auto".into(),
+        model_policy: "balanced".into(),
+        model: "primary/model".into(),
+        fallback_models: String::new(),
+        max_input_tokens: None,
+        max_output_tokens: None,
+        max_usd: None,
+    }
+}
+
+#[test]
+fn resolve_technical_changelog_auto_falls_back_to_release_body_when_changelog_section_missing() {
+    let repo = tempfile::tempdir().unwrap();
+    fs::write(repo.path().join("CHANGELOG.md"), STALE_CHANGELOG).unwrap();
+    fs::write(
+        repo.path().join("release-body.md"),
+        "the real 1.6.0 release body\n",
+    )
+    .unwrap();
+
+    let args = synthesize_args_with_repo(repo.path(), "1.6.0");
+    let mut config = test_synthesis_config();
+    config.changelog_source = "auto".into();
+
+    let technical = resolve_technical_changelog(&args, &config).expect("falls back cleanly");
+
+    assert!(technical.contains("the real 1.6.0 release body"));
+    assert!(!technical.contains("stale unrelated bugfix"));
+}
+
+#[test]
+fn resolve_technical_changelog_explicit_changelog_source_fails_loudly_on_missing_section() {
+    let repo = tempfile::tempdir().unwrap();
+    fs::write(repo.path().join("CHANGELOG.md"), STALE_CHANGELOG).unwrap();
+
+    let args = synthesize_args_with_repo(repo.path(), "1.6.0");
+    let mut config = test_synthesis_config();
+    config.changelog_source = "changelog".into();
+
+    let result = resolve_technical_changelog(&args, &config);
+
+    assert!(
+        result.is_err(),
+        "expected a loud failure, not silent wrong-section synthesis"
+    );
+}
+
+#[test]
+fn classification_notice_is_collapsed_out_of_the_visible_release_body() {
+    let notes = "## Improvements\n\n- Added a safer classifier.\n";
+    let classification = ReleaseClassification {
+        categories: vec!["user-visible".into()],
+        significance: "medium".into(),
+        user_visible: true,
+        breaking: false,
+        security: false,
+        migration_heavy: false,
+        source: "model".into(),
+        model: "test/model".into(),
+        deterministic_signals: vec!["conventional:feat".into()],
+        disagreements: vec![
+            "deterministic floor found user-visible commit signals but model did not".into(),
+        ],
+        reasons: Vec::new(),
+    };
+
+    let rendered = notes_with_classification_notice(notes, &classification);
+
+    assert!(rendered.contains("<details>"));
+    assert!(rendered.contains("</details>"));
+    assert!(rendered.contains("Landmark classification notice"));
+    // The published body up top should read as plain release notes, not debug output.
+    assert!(rendered.starts_with("## Improvements"));
+}


### PR DESCRIPTION
## Summary
- `extract_release_section()` silently fell back to `matches[0]` (the first/most recent CHANGELOG heading) whenever no heading matched the release being synthesized. canary's `CHANGELOG.md` topped out at 1.4.2 while 1.6.0/1.7.0 were being released, so synthesis fed the model the stale 1.4.2 section as "ground truth" for two consecutive newer releases — fluent, confidently wrong release notes describing neither shipped feature.
- `extract_release_section` now returns `None` on a version-heading miss. `resolve_technical_changelog`'s `auto` mode falls through to release-body/PRs (same as a missing/empty CHANGELOG.md today); the explicit `changelog` source now fails loudly, naming the missing version, instead of silently synthesizing from an unrelated section.
- Also collapses the "Landmark classification notice" disagreement blockquote into a `<details>` block so internal classifier-disagreement debug text doesn't read as part of the public release body (secondary leak the audit flagged alongside the grounding bugs).
- Source: `~/.factory-lanes/wave1/landmark-model-audit.md`, finding #2 (P0) + secondary finding.

Note: base branch is `master`; does not depend on #183 (extract-prs range scoping) — the two fixes touch disjoint code paths and can land in either order.

## Test plan
- [x] New regression tests (`crates/landmark/src/synthesis_tests.rs`): version-heading-miss returns `None`, matching-heading still extracts correctly, `auto` mode falls back to release-body on a miss, explicit `changelog` source fails loudly, classification notice renders inside a collapsed `<details>` block
- [x] Fixed a pre-existing `synthesis_cost_policy` replay fixture that was unknowingly relying on the old silent fallback (`CHANGELOG.md` had a `1.2.4` section but the fixture invoked `synthesize --version v1.2.3`) — exactly the bug class this PR eliminates
- [x] `bin/gate` green (fmt, clippy, `cargo test`, `check-version-sync`, `check-action-contract`, `setup`, `replay-action` — 25/25 canonical scenarios pass on this branch, linux build check skipped on macOS host per script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)