### PR TITLE
docs(backlog): widen 005, file synthesis-grounding follow-ups

### DIFF
--- a/backlog.d/005-build-diff-grounded-semver-evidence.md
+++ b/backlog.d/005-build-diff-grounded-semver-evidence.md
@@ -30,3 +30,19 @@ Landmark can distinguish inferred intent, declared intent, and actual breakage.
 ## Notes
 This is the differentiator arc, but it stays behind `003` and `004` so it does
 not build trust claims on top of keyword classification or split version truth.
+
+**Scope widened 2026-07-02** (model usage audit,
+`~/.factory-lanes/wave1/landmark-model-audit.md`): the "ground the model in the
+real diff, not commit-subject text" principle this ticket names for version
+*decisions* applies equally to synthesis *content*. Classification already
+consumes range-scoped `deterministic.commits`/`diff_stats`; synthesis sources
+its "what happened" facts from a separate, independently-resolved changelog
+string (`resolve_technical_changelog`) that can diverge from what
+classification saw. Two production incidents this audit found
+(bitterblossom v1.79.0 unfiltered-PR leak, canary v1.6.0/v1.7.0 stale
+changelog-section fallback) both stemmed from that divergence. The immediate
+grounding bugs are fixed (`extract_prs` now scopes to the release tag range;
+`extract_release_section` no longer silently falls back to the wrong
+section), but the two independent resolution paths still exist. See
+`backlog.d/011-unify-classification-and-synthesis-grounding.md` for the
+sibling ticket that tracks collapsing them into one.

--- a/backlog.d/011-unify-classification-and-synthesis-grounding.md
+++ b/backlog.d/011-unify-classification-and-synthesis-grounding.md
@@ -1,0 +1,69 @@
+# Unify classification and synthesis grounding
+
+Priority: P1 · Status: pending · Estimate: M
+
+## Goal
+Classification and synthesis currently derive "what happened in this release"
+from two independent paths that can silently diverge. Collapse them into one
+grounding source so a bug in one can't feed confidently wrong content through
+the other.
+
+## Context
+`~/.factory-lanes/wave1/landmark-model-audit.md` (2026-07-02 model usage audit)
+found that classification (`classify_release_context_with_deterministic`)
+consumes `deterministic.commits`/`diff_stats` — already correctly scoped to
+`previous_tag..target` via `context_git_range`. Synthesis instead resolves its
+technical changelog independently via `resolve_technical_changelog`, which
+tries `CHANGELOG.md` section extraction, then a fetched GitHub release body,
+then extracted PRs — none of which are cross-checked against the commit range
+classification already computed. Two production incidents traced directly to
+this divergence:
+
+- bitterblossom v1.79.0: no `CHANGELOG.md`, `extract-prs` fetched an unfiltered
+  "last 100 closed PRs" page unrelated to the release, and synthesis
+  faithfully turned it into ~19 fabricated feature bullets for a one-commit
+  release.
+- canary v1.6.0/v1.7.0: `CHANGELOG.md` existed but was stale;
+  `extract_release_section` silently fell back to the wrong (most recent)
+  section, and synthesis produced fluent, confidently wrong notes describing
+  neither shipped feature.
+
+The immediate bugs are fixed (PRs scoped to the release tag range;
+`extract_release_section` fails closed instead of guessing), but the
+structural gap — synthesis and classification trusting different "what
+happened" sources — remains and can recur in a new form.
+
+## Oracle
+- [ ] Synthesis's technical-changelog resolution and classification's
+      deterministic context are demonstrably sourced from the same
+      range-scoped evidence (or synthesis explicitly cross-checks its
+      resolved source against `deterministic.commits` and fails/degrades on
+      material mismatch).
+- [ ] A regression fixture proves that if `resolve_technical_changelog`'s
+      chosen source disagrees with `deterministic.commits` (e.g. commit count
+      or subject keywords), synthesis does not silently proceed with the
+      mismatched source.
+- [ ] `bin/gate` passes.
+
+## Children
+1. Decide the unification shape: either (a) synthesis derives its technical
+   changelog text directly from `deterministic.commits` when no explicit
+   `changelog-source` override is set, or (b) synthesis keeps its existing
+   source order but validates the resolved text against
+   `deterministic.commits` (e.g. commit-count/keyword sanity check) before
+   using it, degrading loudly on mismatch.
+2. Land whichever shape as the default for `changelog-source: auto`; keep
+   explicit `changelog`/`release-body`/`prs` overrides working for repos that
+   deliberately want one source.
+3. Fold in the audit's cheap belt-and-suspenders mitigation: explicit
+   grounding language in the synthesis prompt telling the model to prefer the
+   commit list if the supplied changelog text looks inconsistent with it.
+4. Cross-link with `backlog.d/005-build-diff-grounded-semver-evidence.md`,
+   which names the same "ground the model in the real diff" principle for
+   version-bump decisions.
+
+## Notes
+Filed from the 2026-07-02 model usage audit alongside the P0 fixes for
+`extract_prs` range scoping and `extract_release_section`'s silent fallback.
+Those fixes close the two specific incidents; this ticket is the structural
+follow-up the audit recommended as the highest-leverage remaining risk.

--- a/backlog.d/012-harden-residual-pr-extraction-and-synthesis-idempotency-gaps.md
+++ b/backlog.d/012-harden-residual-pr-extraction-and-synthesis-idempotency-gaps.md
@@ -1,0 +1,55 @@
+# Harden residual PR-extraction and synthesis-idempotency gaps
+
+Priority: P2 · Status: pending · Estimate: S
+
+## Goal
+Close two smaller gaps the 2026-07-02 model usage audit surfaced alongside the
+two P0 grounding bugs (`extract_prs` range scoping, `extract_release_section`
+silent fallback), neither severe enough to block those fixes but both real
+residual risk.
+
+## Context
+`~/.factory-lanes/wave1/landmark-model-audit.md`:
+
+1. **`closed_pull_requests` has no pagination.** It fetches a single page
+   (`per_page=100`) of closed PRs, now filtered client-side to the release's
+   tag range by `filter_prs_by_range`. For a release with more than 100
+   closed PRs merged since the previous tag, in-range PRs merged earlier than
+   GitHub's first 100 (sorted by default, which is creation order — not
+   necessarily merge order) could still be silently dropped from the
+   changelog, understating the release rather than fabricating content. Lower
+   severity than the unfiltered-fetch bug already fixed, but real for
+   high-throughput repos.
+2. **canary's duplicate classification-notice sections.** The audit observed
+   "Bug Fixes" and the classification-notice blockquote appearing twice,
+   worded slightly differently, in the same release body for both v1.6.0 and
+   v1.7.0. The audit's working theory is `synthesize`/`update_release` ran
+   twice without body-replacement idempotency (a retry without a check for
+   "did this already run"). Not confirmed — needs an actual look at the
+   consuming workflow's retry behavior, not just the symptom.
+
+## Oracle
+- [ ] `closed_pull_requests` (or its caller) paginates until either the
+      fetched PRs span past the release's `since` bound or GitHub returns no
+      more pages, so in-range PRs are never dropped solely because they sat
+      past page 1.
+- [ ] The canary duplicate-section symptom is either root-caused (retry
+      without idempotency, confirmed via the consuming workflow) and fixed,
+      or explicitly ruled out with evidence and closed as a non-issue.
+- [ ] `bin/gate` passes.
+
+## Children
+1. Add pagination to `closed_pull_requests`, bounded by the same
+   `previous_tag` commit-date lower bound `extract_prs` already computes —
+   stop paginating once a page's oldest PR is older than `since`.
+2. Investigate canary's actual release workflow run history (or a synthetic
+   repro) for a `synthesize`-then-`update_release` retry path that doesn't
+   check whether the release body already contains synthesized notes before
+   appending again.
+3. If confirmed, make `update_release_body`/the consuming workflow idempotent
+   (e.g. detect and replace rather than append on a rerun).
+
+## Notes
+Both items are secondary to `backlog.d/011-unify-classification-and-synthesis-grounding.md`
+— that ticket addresses the structural cause; this one mops up two smaller,
+independent hardening gaps the same audit pass turned up.


### PR DESCRIPTION
## Summary
- Widens `backlog.d/005`'s scope note to cover synthesis-content grounding (not just version-bump decisions), per the 2026-07-02 model usage audit.
- Files `backlog.d/011` (unify classification's and synthesis's independent grounding paths — the structural cause behind both P0 incidents fixed in #183 and #184) and `backlog.d/012` (residual `closed_pull_requests` pagination gap + canary duplicate-notice investigation).

Docs-only change, no code.

## Test plan
- [x] N/A — markdown only