### PR TITLE
docs(backlog): file model refresh tickets (013, 014)

### DIFF
--- a/backlog.d/013-refresh-model-defaults-and-fix-config-override-bug.md
+++ b/backlog.d/013-refresh-model-defaults-and-fix-config-override-bug.md
@@ -1,0 +1,72 @@
+# Refresh model defaults and fix config-override bug
+
+Priority: P1 · Status: pending · Estimate: S
+
+## Goal
+Replace the stale hardcoded model pins (`openai/gpt-4o-mini` classification,
+`anthropic/claude-sonnet-4` synthesis) with current (July 2026) models, and
+fix `release_classification_models()` silently ignoring `config.model`/
+`config.model_policy` on OpenRouter.
+
+## Context
+`~/.factory-lanes/wave1/landmark-model-refresh.md` (2026-07-02 model refresh
+research, triggered by the operator flagging both pins as "clearly incorrect
+and incredibly dated"). Confirmed stale: `openai/gpt-4o-mini` is a mid-2024
+model with no listing changes since; `anthropic/claude-sonnet-4` has two
+newer same-vendor successors, including Claude Sonnet 5 (released
+2026-06-30, two days before this audit) which is both cheaper ($2/$10 per 1M
+vs Sonnet 4's pricing) and higher quality.
+
+Three sites hardcode model-tier defaults independently: `cheap_model()`
+(synthesis.rs:831), `rich_model()` (synthesis.rs:839), and
+`release_classification_models()` (release_classification.rs:178). The third
+has a live bug: on OpenRouter with `model_policy != "cheap"`, it
+unconditionally pushes `"openai/gpt-4o-mini"` first, ignoring
+`config.model`/`config.model_policy` even when the manifest's own
+`model.primary` field (already defined in
+`schemas/landmark-manifest.v1.schema.json`) is set. The config surface
+exists; classification just doesn't honor it.
+
+## Oracle
+- [ ] Classification's cheap-tier default becomes `deepseek/deepseek-v4-flash`
+      (confirmed $0.089/$0.18 per 1M input/output, 1M context, released
+      2026-04-24); `anthropic/claude-haiku-4.5` is the fallback in the model
+      chain.
+- [ ] Synthesis's rich/balanced-high-significance default becomes
+      `anthropic/claude-sonnet-5` ($2/$10 per 1M); the cheap tier becomes
+      `anthropic/claude-haiku-4.5` ($1/$5 per 1M) — replacing gpt-4o-mini.
+- [ ] `release_classification_models()` respects `config.model` /
+      `config.model_policy` the same way `cheap_model()`/`rich_model()`
+      already do — the manifest's `model.primary` is no longer silently
+      overridden when set.
+- [ ] The three independent default-model sites are collapsed into one
+      `default_model_for_tier(tier, api_url)` source of truth (or an
+      equivalent single point of definition).
+- [ ] Each hardcoded default carries a `// model pin reviewed: YYYY-MM`
+      comment so staleness is grep-able instead of rediscovered from
+      scratch.
+- [ ] A regression fixture covers the config-override bug: with
+      `model.primary` set and `model.policy` not `cheap`, on an OpenRouter
+      API URL, `release_classification_models()` returns the configured
+      model first, not a hardcoded literal.
+- [ ] `bin/gate` passes.
+
+## Children
+1. Add `default_model_for_tier` (or equivalent) as the single source of
+   truth for cheap/rich/classification-cheap defaults; update all three call
+   sites to use it.
+2. Fix `release_classification_models()` to check `config.model`/
+   `config.model_policy` before falling back to the tier default, matching
+   `cheap_model()`/`rich_model()`'s existing precedence.
+3. Update the three literal model IDs to the July 2026 picks above; add the
+   reviewed-date comment convention.
+4. Add the regression fixture for the config-override bug.
+5. Consider a lightweight staleness check (e.g. `bin/gate` warns if a
+   reviewed-date comment is older than ~9-12 months) so this doesn't
+   fossilize again — optional, not blocking for this ticket's oracle.
+
+## Notes
+Filed from the 2026-07-02 model refresh research. Cross-link:
+`backlog.d/011-unify-classification-and-synthesis-grounding.md` (separate,
+input-grounding concern — not model selection); this ticket is purely about
+which model IDs are pinned and whether config actually reaches them.

--- a/backlog.d/014-adopt-structured-output-mode-for-classification.md
+++ b/backlog.d/014-adopt-structured-output-mode-for-classification.md
@@ -1,0 +1,60 @@
+# Adopt structured-output mode for classification
+
+Priority: P2 · Status: pending · Estimate: S
+
+## Goal
+Replace prompt-only JSON compliance for the classification call with native
+`response_format: json_schema` (strict mode) enforcement, removing reliance
+on `extract_json_object`'s manual brace-matching to recover valid JSON from
+free-form model output.
+
+## Context
+`~/.factory-lanes/wave1/landmark-model-refresh.md` (2026-07-02 model refresh
+research, Part 2 architecture re-exam). Classification
+(`request_release_classification`, release_classification.rs) asks for
+strict JSON purely via prompt text — "Return only one strict JSON object
+matching the requested schema" — and the already-constructed `output_schema`
+object embedded in the request payload is descriptive prompt content only,
+never passed as an actual `response_format` field. The response is then
+parsed with `extract_json_object` (release_classification.rs:318), a manual
+string-extraction routine, rather than relying on a schema-enforced response.
+
+Every model in the classification roster (DeepSeek V4 family, Claude family,
+GPT-5.x family) supports schema-enforced structured output on OpenRouter as
+of mid-2026. This is the one concrete place the pipeline lags current
+practice; the fix is mechanical — the `output_schema` value already
+constructed for the prompt can be promoted directly into the request's
+`response_format` field.
+
+## Oracle
+- [ ] `request_release_classification`'s HTTP payload includes a
+      `response_format: {"type": "json_schema", "json_schema": {...},
+      "strict": true}` (or the closest OpenRouter/model-supported
+      equivalent) built from the existing `output_schema` value, instead of
+      relying solely on prompt-text instruction.
+- [ ] `extract_json_object` either becomes a defensive fallback (used only
+      when `response_format` isn't honored by a given model/provider) or is
+      removed if schema enforcement makes it unreachable in practice — pick
+      one and make the reasoning explicit in the code/commit.
+- [ ] A regression fixture exercises a real (or realistically mocked)
+      response under the new `response_format` and confirms classification
+      still parses correctly.
+- [ ] `bin/gate` passes.
+
+## Children
+1. Add the `response_format` field to the classification request payload,
+   derived from the existing `output_schema`.
+2. Decide `extract_json_object`'s fate (fallback vs. removal) and implement.
+3. Add/update the regression fixture.
+4. Spot-check against at least one non-OpenAI model in the roster (e.g.
+   DeepSeek or Claude via OpenRouter) to confirm `response_format` is
+   honored cross-provider, not just by OpenAI-shaped backends — OpenRouter's
+   passthrough behavior for `response_format` varies by upstream provider.
+
+## Notes
+Filed from the 2026-07-02 model refresh research. Not in scope: the
+grounding-language prompt nudge (already a child of
+`backlog.d/011-unify-classification-and-synthesis-grounding.md`) and the
+classification-notice blockquote leaking into published release bodies
+(named in the original `landmark-model-audit.md` secondary recommendations,
+not re-ticketed here — output-hygiene issue, not a model/architecture one).


### PR DESCRIPTION
## Summary
- Files `backlog.d/013` — refresh the stale `openai/gpt-4o-mini` (classification) / `anthropic/claude-sonnet-4` (synthesis) pins to current July 2026 models (DeepSeek V4 Flash + Claude Haiku 4.5 for classification, Claude Sonnet 5 + Haiku 4.5 for synthesis), and fix a live bug where `release_classification_models()` silently ignores `config.model`/`config.model_policy` on OpenRouter.
- Files `backlog.d/014` — adopt native `response_format: json_schema` structured-output enforcement for classification instead of prompt-only JSON compliance parsed via manual brace-matching (`extract_json_object`).
- Both tickets are sourced from a full model-refresh research pass triggered by the operator flagging the current pins as dated: `~/.factory-lanes/wave1/landmark-model-refresh.md` (pricing table, architecture re-exam, verdict that the classify/synthesize split is correct — not over-engineered) and `~/.factory-lanes/wave1/landmark-outputs.md` (verbatim last-6 release notes with quality annotations).
- Docs-only change — no runtime code touched. Does not conflict with the parallel grounding-bug work already staged on `backlog.d/005`/`011`/`012` (untouched by this branch).

## Test plan
- [ ] `bin/gate` (docs-only backlog files; no runtime change to verify beyond markdown lint if the gate checks it)