### PR TITLE
feat(release-kit): adopt native structured output for classification

### DIFF
--- a/crates/landmark/src/classification_tests.rs
+++ b/crates/landmark/src/classification_tests.rs
@@ -128,6 +128,22 @@ fn model_classifier_uses_commit_diff_context_and_preserves_floor() {
     let classifier_context: Value =
         serde_json::from_str(payload["messages"][1]["content"].as_str().unwrap()).unwrap();
     assert_eq!(payload["model"], "test/model");
+    // Ticket 014: classification enforces schema-constrained output natively
+    // instead of relying on prompt-text compliance alone.
+    assert_eq!(payload["response_format"]["type"], "json_schema");
+    assert_eq!(payload["response_format"]["json_schema"]["strict"], true);
+    assert_eq!(
+        payload["response_format"]["json_schema"]["schema"]["required"],
+        json!([
+            "categories",
+            "significance",
+            "user_visible",
+            "breaking",
+            "security",
+            "migration_heavy",
+            "reasons"
+        ])
+    );
     assert!(
         classifier_context["deterministic"]["commits"]
             .as_array()

--- a/crates/landmark/src/release_classification.rs
+++ b/crates/landmark/src/release_classification.rs
@@ -215,47 +215,49 @@ pub(crate) fn request_release_classification(
     sources: &[ContextSource],
     deterministic: &DeterministicReleaseContext,
 ) -> Result<ReleaseClassification> {
+    let output_schema = json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+            "categories",
+            "significance",
+            "user_visible",
+            "breaking",
+            "security",
+            "migration_heavy",
+            "reasons"
+        ],
+        "properties": {
+            "categories": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "user-visible",
+                        "docs-only",
+                        "chore-only",
+                        "dependency-only",
+                        "internal-tooling",
+                        "breaking",
+                        "security",
+                        "migration-heavy"
+                    ]
+                }
+            },
+            "significance": { "type": "string", "enum": ["low", "medium", "high"] },
+            "user_visible": { "type": "boolean" },
+            "breaking": { "type": "boolean" },
+            "security": { "type": "boolean" },
+            "migration_heavy": { "type": "boolean" },
+            "reasons": { "type": "array", "items": { "type": "string" } }
+        }
+    });
     let input = json!({
         "task": "classify_release_importance",
         "rendered_changelog_context": technical,
         "context_sources": sources,
         "deterministic": deterministic,
-        "output_schema": {
-            "type": "object",
-            "required": [
-                "categories",
-                "significance",
-                "user_visible",
-                "breaking",
-                "security",
-                "migration_heavy",
-                "reasons"
-            ],
-            "properties": {
-                "categories": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "user-visible",
-                            "docs-only",
-                            "chore-only",
-                            "dependency-only",
-                            "internal-tooling",
-                            "breaking",
-                            "security",
-                            "migration-heavy"
-                        ]
-                    }
-                },
-                "significance": { "type": "string", "enum": ["low", "medium", "high"] },
-                "user_visible": { "type": "boolean" },
-                "breaking": { "type": "boolean" },
-                "security": { "type": "boolean" },
-                "migration_heavy": { "type": "boolean" },
-                "reasons": { "type": "array", "items": { "type": "string" } }
-            }
-        }
+        "output_schema": output_schema.clone()
     });
     let payload = json!({
         "model": model,
@@ -270,7 +272,20 @@ pub(crate) fn request_release_classification(
             }
         ],
         "temperature": 0,
-        "max_tokens": 700
+        "max_tokens": 700,
+        // Native schema enforcement, not just the prompt-text instruction
+        // above. Every model in the classification roster (DeepSeek V4,
+        // Claude, GPT-5.x families) supports response_format: json_schema
+        // strict mode on OpenRouter as of mid-2026 — see
+        // backlog.d/014-adopt-structured-output-mode-for-classification.md.
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "release_classification",
+                "strict": true,
+                "schema": output_schema
+            }
+        }
     });
     let response = curl_json("POST", api_url, Some(api_key), Some(&payload))?;
     if !(200..300).contains(&response.status) {
@@ -310,6 +325,14 @@ pub(crate) fn parse_model_release_classification(
     })
 }
 
+/// Kept as a defensive fallback, not removed: `response_format: json_schema`
+/// (strict mode) makes `content` a bare JSON object for every model that
+/// honors it, so the `starts_with('{')` fast path below covers the common
+/// case in one comparison. The brace-scan only does real work against a
+/// provider that ignores `response_format` and wraps the object in prose or
+/// markdown fencing — cheap insurance, not the primary compliance mechanism
+/// anymore. See
+/// backlog.d/014-adopt-structured-output-mode-for-classification.md.
 pub(crate) fn extract_json_object(content: &str) -> Result<&str> {
     let trimmed = content.trim();
     if trimmed.starts_with('{') && trimmed.ends_with('}') {


### PR DESCRIPTION
## Summary
- Promotes classification's existing `output_schema` value into a real `response_format: {type: json_schema, strict: true}` request field instead of relying on prompt-text-only JSON compliance.
- Keeps `extract_json_object` as a defensive fallback (documented inline) rather than removing it: with strict mode honored, `content` is already a bare JSON object, so the `starts_with('{')` fast path covers the common case; the brace-scan only earns its keep against a provider that ignores `response_format`.

## Test plan
- [x] `cargo test --locked` — 87 passed. `model_classifier_uses_commit_diff_context_and_preserves_floor` now asserts the outgoing payload carries `response_format.json_schema.strict = true` with the matching `required` field list, and that classification still parses end to end through the fake server.
- [x] `bin/gate` green locally (fmt, clippy -D warnings, cargo test, check-version-sync, check-action-contract, setup, replay-action).

Refs `backlog.d/014-adopt-structured-output-mode-for-classification.md`. Builds on #187 (merged) for the model-default refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)