### PR TITLE
docs(manifest): fill crates.io publish metadata

### DIFF
--- a/crates/landmark/Cargo.toml
+++ b/crates/landmark/Cargo.toml
@@ -2,6 +2,12 @@
 name = "landmark"
 version = "1.26.0"
 edition = "2024"
+description = "Portable release-intelligence runtime for repositories using conventional commits"
+license = "MIT"
+repository = "https://github.com/misty-step/landmark"
+readme = "../../README.md"
+keywords = ["release", "changelog", "semver", "conventional-commits", "cli"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 chrono = { version = "0.4.42", default-features = false, features = ["clock", "std"] }


### PR DESCRIPTION
## Summary
- Adds `description`, `license`, `repository`, `readme`, `keywords`, and `categories` to `crates/landmark/Cargo.toml`
- Resolves the `cargo publish` warning: "manifest has no description, license, license-file, documentation, homepage or repository"
- Package name (`landmark`) left unchanged -- that's blocked on a separate decision (crates.io already has an unrelated crate named `landmark`; filed as bridge card session-14 for the name/token call)

## Test plan
- [x] `cargo fmt --check`
- [x] `bin/gate` (full local gate: fmt, clippy, tests, architecture check, release-workflow replay) -- exit 0
- [x] `cargo publish --dry-run --allow-dirty -p landmark` -- packages and verifies clean, no metadata warnings, README pulled into the tarball (49 -> 50 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata with a description, license, repository link, readme reference, keywords, and categories.
  * Improved the crate’s published information for better discoverability and project clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->