### PR TITLE
feat(release): post release kit feed events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,9 @@ jobs:
 
       - name: Synthesize landed release notes
         uses: ./
+        env:
+          RELEASE_FEED_URL: ${{ secrets.RELEASE_FEED_URL }}
+          RELEASE_FEED_SECRET: ${{ secrets.RELEASE_FEED_SECRET }}
         with:
           mode: synthesis-only
           release-tag: ${{ needs.publish-landed-release.outputs.release_tag }}

--- a/README.md
+++ b/README.md
@@ -378,13 +378,26 @@ a short classification notice to the generated release notes.
 
 Use `landmark run --provider local --repo-root .` to write a release-kit
 plan at `.landmark/run/release-kit.json` and record its schema and hash in
-`.landmark/run/evidence.json`. `--dry-run` keeps the filesystem untouched and
-prints the same `release_kit` object inside the stdout evidence packet. Low
-internal releases keep the kit to Landmark-owned changelog and notes evidence;
+`.landmark/run/evidence.json`; the evidence packet includes the deterministic
+version decision and changed-file list so downstream producers do not have to
+re-read git state. `--dry-run` keeps the filesystem untouched and prints the
+same `release_kit` object inside the stdout evidence packet. Low internal
+releases keep the kit to Landmark-owned changelog and notes evidence;
 high-importance, security, breaking, or migration-heavy releases add planned
 producer-adapter artifacts such as migration guides, docs updates, blog drafts,
 and demo videos with explicit handoff contracts, evidence paths, and pending
 approval state.
+
+`landmark notify-release-feed` is the first remote-service producer adapter for
+the release kit. It reads `.landmark/run/evidence.json` and
+`.landmark/run/release-kit.json`, fills the text-floor artifacts
+(`version-decision`, `changed-files`, and `changelog-diff`) as produced
+producer-adapter outputs, and POSTs the full `landmark.release-kit.v1` JSON body
+to the receiver. The adapter uses the same signature scheme as `notify-webhook`:
+`X-Signature-256: sha256=<hmac>`, computed over the raw JSON body. Configure it
+with `RELEASE_FEED_URL` and `RELEASE_FEED_SECRET`; `LANDMARK_RELEASE_FEED_*` and
+`RELEASE_KIT_FEED_*` are accepted aliases. Missing URL or secret config is a
+clean skip.
 
 Use `landmark backfill --repo-root . --since <tag> --mode artifacts-only
 --dry-run` to preview historical artifact migration for repositories that
@@ -458,10 +471,11 @@ distribution steps:
   balanced policy, or manifest budget limits are treated as successful policy
   outcomes. Release-body mutation and artifact writes are skipped, while
   `synthesis-status.context.cost` records the reason.
-- External GitHub, webhook, Slack, and LLM calls made by the Rust runtime use
-  the shared `curl_json` policy (`--connect-timeout`, `--max-time`, retries for
+- External GitHub, webhook, release-feed, Slack, and LLM calls made by the Rust
+  runtime use bounded curl calls (`--connect-timeout`, `--max-time`, retries for
   429/5xx). `replay-action --scenario http_resilience_policy` exercises slow,
-  throttled, and failing providers, and
+  throttled, and failing providers, `replay-action --scenario release_feed_adapter`
+  exercises the signed release-kit receiver path, and
   `replay-action --scenario action_side_effect_coverage` fails if `action.yml`
   invokes a Landmark subcommand without replay coverage.
 - Generated `release-notes` output uses a collision-resistant GitHub output

--- a/action.yml
+++ b/action.yml
@@ -863,6 +863,56 @@ runs:
           echo "::warning::Webhook notification failed; release continues."
         fi
 
+    - name: Send release kit feed event
+      id: notify_release_feed
+      if: steps.resolve_release.outputs.released == 'true' && steps.write_artifacts.outputs.succeeded == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        set_output() {
+          local key="$1"
+          local value="$2"
+          printf '%s=%s\n' "${key}" "${value}" >> "${GITHUB_OUTPUT}"
+        }
+
+        set_output "sent" "false"
+        set_output "skipped" "false"
+
+        receiver_url="${RELEASE_FEED_URL:-}"
+        if [ -z "${receiver_url}" ]; then
+          receiver_url="${LANDMARK_RELEASE_FEED_URL:-}"
+        fi
+        if [ -z "${receiver_url}" ]; then
+          receiver_url="${RELEASE_KIT_FEED_URL:-}"
+        fi
+
+        receiver_secret="${RELEASE_FEED_SECRET:-}"
+        if [ -z "${receiver_secret}" ]; then
+          receiver_secret="${LANDMARK_RELEASE_FEED_SECRET:-}"
+        fi
+        if [ -z "${receiver_secret}" ]; then
+          receiver_secret="${RELEASE_KIT_FEED_SECRET:-}"
+        fi
+
+        if [ -z "${receiver_url}" ] || [ -z "${receiver_secret}" ]; then
+          echo "::notice::Release kit feed event skipped: receiver URL or secret is not configured."
+          set_output "skipped" "true"
+          exit 0
+        fi
+
+        feed_log="${RUNNER_TEMP}/landmark-release-feed.log"
+        if "${LANDMARK_BIN}" notify-release-feed \
+          --evidence-file "${RUNNER_TEMP}/landmark-artifacts-evidence.json" \
+          --release-kit-file "${RUNNER_TEMP}/landmark-run/release-kit.json" \
+          --receipt-file "${RUNNER_TEMP}/landmark-release-feed-receipt.json" \
+          > "${RUNNER_TEMP}/landmark-release-feed.stdout" \
+          2> "${feed_log}"; then
+          set_output "sent" "true"
+        else
+          echo "::warning::Release kit feed event failed; release continues."
+        fi
+
     - name: Send Slack notification
       id: notify_slack
       if: inputs.slack-webhook-url != '' && steps.resolve_release.outputs.released == 'true' && steps.write_artifacts.outputs.succeeded == 'true'

--- a/crates/landmark/src/cli.rs
+++ b/crates/landmark/src/cli.rs
@@ -41,6 +41,8 @@ pub(crate) enum Commands {
     UpdateFeed(UpdateFeedArgs),
     /// POST release notes to a configured webhook endpoint
     NotifyWebhook(NotifyWebhookArgs),
+    /// POST an enriched release-kit event to a configured release feed receiver
+    NotifyReleaseFeed(NotifyReleaseFeedArgs),
     /// POST release notes to a configured Slack webhook
     NotifySlack(NotifySlackArgs),
     /// Compute a release decision and write technical/public release artifacts
@@ -357,6 +359,23 @@ pub(crate) struct NotifyWebhookArgs {
     pub(crate) release_url: String,
     #[arg(long = "notes-file")]
     pub(crate) notes_file: PathBuf,
+}
+
+#[derive(Args)]
+pub(crate) struct NotifyReleaseFeedArgs {
+    #[arg(long = "receiver-url", alias = "feed-url", default_value = "")]
+    pub(crate) receiver_url: String,
+    #[arg(long = "receiver-secret", alias = "feed-secret", default_value = "")]
+    pub(crate) receiver_secret: String,
+    #[arg(long = "evidence-file", default_value = ".landmark/run/evidence.json")]
+    pub(crate) evidence_file: PathBuf,
+    #[arg(
+        long = "release-kit-file",
+        default_value = ".landmark/run/release-kit.json"
+    )]
+    pub(crate) release_kit_file: PathBuf,
+    #[arg(long = "receipt-file", default_value = "")]
+    pub(crate) receipt_file: PathBuf,
 }
 
 #[derive(Args)]
@@ -768,6 +787,7 @@ pub(crate) fn run(cli: Cli) -> Result<()> {
         Commands::WriteArtifacts(args) => write_artifacts(args),
         Commands::UpdateFeed(args) => update_feed(args),
         Commands::NotifyWebhook(args) => notify_webhook(args),
+        Commands::NotifyReleaseFeed(args) => notify_release_feed(args),
         Commands::NotifySlack(args) => notify_slack(args),
         Commands::Run(args) => run_pipeline(args),
         Commands::FloatingTag(args) => {

--- a/crates/landmark/src/describe.rs
+++ b/crates/landmark/src/describe.rs
@@ -292,6 +292,15 @@ pub(crate) fn command_contracts() -> Vec<CommandContract> {
             json_output: false,
         },
         CommandContract {
+            command: "notify-release-feed",
+            mode: "producer-adapter",
+            mutates: true,
+            preview: "cleanly skips when receiver URL or secret config is absent; otherwise sends one signed release-kit event",
+            stdout: "ReleaseFeedReceipt JSON",
+            stderr: "logs and errors only",
+            json_output: true,
+        },
+        CommandContract {
             command: "notify-slack",
             mode: "notification-adapter",
             mutates: true,

--- a/crates/landmark/src/main.rs
+++ b/crates/landmark/src/main.rs
@@ -31,6 +31,8 @@ mod pr_range;
 mod providers;
 mod release_body;
 mod release_classification;
+#[cfg(test)]
+mod release_feed_tests;
 mod release_kit;
 mod release_kit_contract;
 #[cfg(test)]

--- a/crates/landmark/src/release_feed_tests.rs
+++ b/crates/landmark/src/release_feed_tests.rs
@@ -1,0 +1,238 @@
+use super::*;
+
+#[test]
+fn notify_release_feed_posts_signed_release_kit_with_text_floor_artifacts() {
+    let repo = tempfile::tempdir().unwrap();
+    let run_dir = repo.path().join(".landmark/run");
+    fs::create_dir_all(&run_dir).unwrap();
+    let technical_path = run_dir.join("technical-changelog.md");
+    fs::write(
+        &technical_path,
+        "## Technical Changelog v1.2.3\n\n- feat(feed): publish release evidence (abc1234)\n",
+    )
+    .unwrap();
+    let technical_sha = sha256_hex(fs::read(&technical_path).unwrap().as_slice());
+    let release_kit_path = run_dir.join("release-kit.json");
+    let evidence_path = run_dir.join("evidence.json");
+    let release_kit = json!({
+        "schema_version": "landmark.release-kit.v1",
+        "generated_at": "2026-07-03T12:00:00Z",
+        "product": {"name": "Landmark", "repository": "misty-step/landmark", "audience": "developer", "description": "Release intelligence"},
+        "release": {
+            "tag": "v1.2.3",
+            "version": "1.2.3",
+            "previous_tag": "v1.2.2",
+            "repository": "misty-step/landmark",
+            "release_url": "https://github.com/misty-step/landmark/releases/tag/v1.2.3",
+            "version_decision": {
+                "latest_tag": "v1.2.2",
+                "bump": "minor",
+                "commit_count": 1,
+                "conventional_commit_count": 1,
+                "range": "v1.2.2..HEAD",
+                "decisive_commit": "feat(feed): publish release evidence (abc1234)",
+                "unknown_commits": []
+            }
+        },
+        "classification": {"importance": "medium", "audiences": ["developer"], "why_it_matters": "release feed evidence"},
+        "artifacts": [
+            {
+                "id": "technical-changelog",
+                "kind": "technical_changelog",
+                "audience": "developer-operator",
+                "owner": "landmark",
+                "status": "produced",
+                "path": technical_path.display().to_string(),
+                "sha256": technical_sha,
+                "acceptance": ["Preserves raw commit subjects."]
+            },
+            {
+                "id": "release-notes",
+                "kind": "release_notes",
+                "audience": "developer",
+                "owner": "landmark",
+                "status": "produced",
+                "path": "docs/releases/v1.2.3.md",
+                "sha256": "notes-sha",
+                "acceptance": ["Summarizes the release."]
+            }
+        ],
+        "producer_contracts": [],
+        "provenance": [
+            {"artifact_id": "technical-changelog", "sources": ["git:v1.2.2..HEAD"]},
+            {"artifact_id": "release-notes", "sources": ["git:v1.2.2..HEAD"]}
+        ],
+        "approvals": [
+            {"artifact_id": "technical-changelog", "state": "not-required"},
+            {"artifact_id": "release-notes", "state": "not-required"}
+        ],
+        "status": {"complete": true, "blocked": false, "summary": "fixture kit"}
+    });
+    let evidence = json!({
+        "provider": "github",
+        "generated_at": "2026-07-03T12:00:00Z",
+        "repo_root": repo.path().display().to_string(),
+        "repository": "misty-step/landmark",
+        "release_tag": "v1.2.3",
+        "version": "1.2.3",
+        "previous_tag": "v1.2.2",
+        "source": "git_range",
+        "technical_changelog_sha256": technical_sha,
+        "notes_sha256": "notes-sha",
+        "version_decision": release_kit["release"]["version_decision"].clone(),
+        "changed_files": ["crates/landmark/src/release_ops/artifacts.rs", ".github/workflows/release.yml"],
+        "artifacts": {
+            "technical_changelog": technical_path.display().to_string(),
+            "technical_changelog_audience": "internal-developer-operator",
+            "technical_changelog_schema": "landmark.internal-technical-changelog.v1",
+            "markdown": "docs/releases/v1.2.3.md",
+            "public_notes_audience": "developer",
+            "public_notes_schema": "landmark.public-release-notes.v1",
+            "plaintext": "docs/releases/v1.2.3.txt",
+            "html": "docs/releases/v1.2.3.html",
+            "json": "docs/releases/releases.json",
+            "rss": "",
+            "evidence": evidence_path.display().to_string(),
+            "release_kit": release_kit_path.display().to_string(),
+            "release_kit_schema": "landmark.release-kit.v1",
+            "release_kit_sha256": "kit-sha"
+        },
+        "release_kit": release_kit,
+        "publication": {
+            "provider": "github",
+            "enabled": true,
+            "release_body_updated": true,
+            "release_url": "https://github.com/misty-step/landmark/releases/tag/v1.2.3",
+            "status": "updated"
+        }
+    });
+    fs::write(
+        &release_kit_path,
+        serde_json::to_string_pretty(&evidence["release_kit"]).unwrap() + "\n",
+    )
+    .unwrap();
+    fs::write(
+        &evidence_path,
+        serde_json::to_string_pretty(&evidence).unwrap() + "\n",
+    )
+    .unwrap();
+
+    let receiver = start_release_feed_capture("feed-secret");
+    let receipt_path = run_dir.join("feed-receipt.json");
+
+    notify_release_feed(NotifyReleaseFeedArgs {
+        receiver_url: receiver.url.clone(),
+        receiver_secret: "feed-secret".into(),
+        evidence_file: evidence_path.clone(),
+        release_kit_file: release_kit_path.clone(),
+        receipt_file: receipt_path.clone(),
+    })
+    .unwrap();
+
+    let captured = receiver.state.lock().unwrap().clone().unwrap();
+    assert_eq!(captured.path, "/v1/events");
+    assert_eq!(
+        captured.signature,
+        compute_signature("feed-secret", captured.body.as_bytes()).unwrap()
+    );
+    let payload: Value = serde_json::from_str(&captured.body).unwrap();
+    assert_eq!(payload["schema_version"], "landmark.release-kit.v1");
+    assert_release_feed_artifact(&payload, "version-decision", "other");
+    assert_release_feed_artifact(&payload, "changed-files", "other");
+    assert_release_feed_artifact(&payload, "changelog-diff", "technical_changelog");
+    assert!(
+        payload["producer_contracts"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|contract| contract["id"] == "release-feed-receiver"
+                && contract["adapter_kind"] == "remote-service")
+    );
+    let receipt: Value = serde_json::from_str(&fs::read_to_string(receipt_path).unwrap()).unwrap();
+    assert_eq!(receipt["sent"], true);
+    assert_eq!(receipt["status"], 202);
+}
+
+#[derive(Clone, Debug)]
+struct CapturedReleaseFeedRequest {
+    path: String,
+    signature: String,
+    body: String,
+}
+
+struct ReleaseFeedCapture {
+    url: String,
+    state: Arc<Mutex<Option<CapturedReleaseFeedRequest>>>,
+}
+
+fn start_release_feed_capture(secret: &'static str) -> ReleaseFeedCapture {
+    use tiny_http::{Header, Method, Response, Server};
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = Server::from_listener(listener, None).unwrap();
+    let state = Arc::new(Mutex::new(None));
+    let thread_state = Arc::clone(&state);
+    thread::spawn(move || {
+        let mut request = server.incoming_requests().next().unwrap();
+        let path = request.url().to_string();
+        let method = request.method().clone();
+        let signature = request
+            .headers()
+            .iter()
+            .find(|header| header.field.equiv("X-Signature-256"))
+            .map(|header| header.value.as_str().to_string())
+            .unwrap_or_default();
+        let mut body = String::new();
+        request.as_reader().read_to_string(&mut body).unwrap();
+        let expected = compute_signature(secret, body.as_bytes()).unwrap();
+        let payload: Value = serde_json::from_str(&body).unwrap_or_else(|_| json!({}));
+        let has_text_floor = ["version-decision", "changed-files", "changelog-diff"]
+            .iter()
+            .all(|id| {
+                payload["artifacts"]
+                    .as_array()
+                    .unwrap_or(&Vec::new())
+                    .iter()
+                    .any(|artifact| artifact["id"] == *id && artifact["status"] == "produced")
+            });
+        *thread_state.lock().unwrap() = Some(CapturedReleaseFeedRequest {
+            path: path.clone(),
+            signature: signature.clone(),
+            body,
+        });
+        let status = if method == Method::Post
+            && path == "/v1/events"
+            && signature == expected
+            && has_text_floor
+        {
+            202
+        } else {
+            400
+        };
+        let _ = request.respond(
+            Response::from_string("{}")
+                .with_status_code(status)
+                .with_header(
+                    Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap(),
+                ),
+        );
+    });
+    ReleaseFeedCapture {
+        url: format!("http://{addr}/v1/events"),
+        state,
+    }
+}
+
+fn assert_release_feed_artifact(payload: &Value, id: &str, kind: &str) {
+    let artifact = payload["artifacts"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|artifact| artifact["id"] == id)
+        .unwrap_or_else(|| panic!("missing artifact {id}"));
+    assert_eq!(artifact["kind"], kind);
+    assert_eq!(artifact["owner"], "producer-adapter");
+    assert_eq!(artifact["status"], "produced");
+    assert!(artifact["sha256"].as_str().unwrap_or_default().len() >= 64);
+}

--- a/crates/landmark/src/release_ops/feed_adapter.rs
+++ b/crates/landmark/src/release_ops/feed_adapter.rs
@@ -1,0 +1,330 @@
+use crate::*;
+
+const SIGNATURE_HEADER: &str = "X-Signature-256";
+const FEED_RECEIVER_CONTRACT_ID: &str = "release-feed-receiver";
+
+pub(crate) fn notify_release_feed(args: NotifyReleaseFeedArgs) -> Result<()> {
+    let receipt = notify_release_feed_receipt(args)?;
+    println!("{}", serde_json::to_string_pretty(&receipt)?);
+    Ok(())
+}
+
+pub(crate) fn notify_release_feed_receipt(args: NotifyReleaseFeedArgs) -> Result<Value> {
+    let Some(receiver_url) = release_feed_config(
+        &args.receiver_url,
+        &[
+            "RELEASE_FEED_URL",
+            "LANDMARK_RELEASE_FEED_URL",
+            "RELEASE_KIT_FEED_URL",
+        ],
+    ) else {
+        return write_release_feed_skip(&args.receipt_file, "missing RELEASE_FEED_URL");
+    };
+    let Some(receiver_secret) = release_feed_config(
+        &args.receiver_secret,
+        &[
+            "RELEASE_FEED_SECRET",
+            "LANDMARK_RELEASE_FEED_SECRET",
+            "RELEASE_KIT_FEED_SECRET",
+        ],
+    ) else {
+        return write_release_feed_skip(&args.receipt_file, "missing RELEASE_FEED_SECRET");
+    };
+
+    validate_url(&receiver_url)?;
+    let evidence: Value = serde_json::from_str(&fs::read_to_string(&args.evidence_file)?)?;
+    let mut release_kit: Value =
+        serde_json::from_str(&fs::read_to_string(&args.release_kit_file)?)?;
+    enrich_release_feed_kit(
+        &mut release_kit,
+        &evidence,
+        &args.evidence_file,
+        &args.release_kit_file,
+        &args.receipt_file,
+    )?;
+    let body = serde_json::to_string_pretty(&release_kit)? + "\n";
+    let signature = compute_signature(&receiver_secret, body.as_bytes())?;
+    let response = post_release_feed_event(&receiver_url, &signature, &body)?;
+    let receipt = json!({
+        "sent": (200..300).contains(&response.status),
+        "skipped": false,
+        "status": response.status,
+        "release_tag": evidence["release_tag"],
+        "artifact_count": release_kit["artifacts"].as_array().map(Vec::len).unwrap_or_default(),
+        "producer_contract": FEED_RECEIVER_CONTRACT_ID,
+    });
+    write_json_if_requested(&args.receipt_file, &receipt)?;
+    if (200..300).contains(&response.status) {
+        Ok(receipt)
+    } else {
+        Err(format!("release feed receiver returned HTTP {}", response.status).into())
+    }
+}
+
+fn release_feed_config(arg_value: &str, env_names: &[&str]) -> Option<String> {
+    trimmed_option(arg_value).or_else(|| {
+        env_names
+            .iter()
+            .filter_map(|name| env::var(name).ok())
+            .find_map(|value| trimmed_option(&value))
+    })
+}
+
+fn write_release_feed_skip(receipt_file: &Path, reason: &str) -> Result<Value> {
+    let receipt = json!({
+        "sent": false,
+        "skipped": true,
+        "reason": reason,
+    });
+    write_json_if_requested(receipt_file, &receipt)?;
+    Ok(receipt)
+}
+
+fn enrich_release_feed_kit(
+    release_kit: &mut Value,
+    evidence: &Value,
+    evidence_file: &Path,
+    release_kit_file: &Path,
+    receipt_file: &Path,
+) -> Result<()> {
+    if release_kit["schema_version"].as_str() != Some(release_kit::SCHEMA_VERSION) {
+        return Err("release kit schema_version must be landmark.release-kit.v1".into());
+    }
+    let version_decision = evidence
+        .get("version_decision")
+        .ok_or("evidence missing version_decision")?;
+    let changed_files = evidence
+        .get("changed_files")
+        .and_then(Value::as_array)
+        .ok_or("evidence missing changed_files")?;
+    let changelog_path = evidence
+        .pointer("/artifacts/technical_changelog")
+        .and_then(Value::as_str)
+        .and_then(trimmed_option)
+        .ok_or("evidence missing artifacts.technical_changelog")?;
+    let changelog_sha = evidence["technical_changelog_sha256"]
+        .as_str()
+        .and_then(trimmed_option)
+        .unwrap_or_else(|| {
+            fs::read(&changelog_path)
+                .map(|bytes| sha256_hex(&bytes))
+                .unwrap_or_default()
+        });
+    if changelog_sha.is_empty() {
+        return Err("evidence missing technical_changelog_sha256".into());
+    }
+
+    if let Some(release_decision) = release_kit.pointer_mut("/release/version_decision") {
+        *release_decision = version_decision.clone();
+    }
+
+    let evidence_ref = evidence_file.display().to_string();
+    let release_kit_ref = release_kit_file.display().to_string();
+    upsert_artifact(
+        release_kit,
+        json!({
+            "id": "version-decision",
+            "kind": "other",
+            "audience": "developer-operator",
+            "owner": "producer-adapter",
+            "status": "produced",
+            "path": format!("{evidence_ref}#/version_decision"),
+            "sha256": sha256_json(version_decision)?,
+            "acceptance": [
+                "Carries the exact deterministic version decision from run-evidence.v1.",
+                "Names the bump, release range, decisive commit, and unknown commits."
+            ]
+        }),
+    )?;
+    upsert_artifact(
+        release_kit,
+        json!({
+            "id": "changed-files",
+            "kind": "other",
+            "audience": "developer-operator",
+            "owner": "producer-adapter",
+            "status": "produced",
+            "path": format!("{evidence_ref}#/changed_files"),
+            "sha256": sha256_json(&Value::Array(changed_files.clone()))?,
+            "acceptance": [
+                "Carries the release changed-file list from run-evidence.v1.",
+                "Lets the feed receiver show scope without re-reading the repository."
+            ]
+        }),
+    )?;
+    upsert_artifact(
+        release_kit,
+        json!({
+            "id": "changelog-diff",
+            "kind": "technical_changelog",
+            "audience": "developer-operator",
+            "owner": "producer-adapter",
+            "status": "produced",
+            "path": changelog_path,
+            "sha256": changelog_sha,
+            "acceptance": [
+                "Points at the technical changelog generated from the release range.",
+                "Matches the technical_changelog_sha256 recorded in run-evidence.v1."
+            ]
+        }),
+    )?;
+
+    for artifact_id in ["version-decision", "changed-files", "changelog-diff"] {
+        upsert_provenance(
+            release_kit,
+            json!({
+                "artifact_id": artifact_id,
+                "sources": [
+                    format!("run_evidence:{evidence_ref}"),
+                    format!("release_kit:{release_kit_ref}")
+                ],
+                "notes": "Produced by the release feed adapter from Landmark evidence."
+            }),
+        )?;
+        upsert_approval(
+            release_kit,
+            json!({
+                "artifact_id": artifact_id,
+                "state": "not-required",
+                "approver": "release-feed-adapter",
+                "reason": "Text-floor artifact is derived directly from run evidence."
+            }),
+        )?;
+    }
+    upsert_producer_contract(
+        release_kit,
+        json!({
+            "id": FEED_RECEIVER_CONTRACT_ID,
+            "producer": "release feed receiver",
+            "adapter_kind": "remote-service",
+            "input_artifacts": ["technical-changelog", "release-notes"],
+            "output_artifacts": ["version-decision", "changed-files", "changelog-diff"],
+            "command": "POST /v1/events with X-Signature-256 over the raw release-kit JSON body",
+            "mutates": true,
+            "acceptance": [
+                "Receiver validates the HMAC-SHA256 signature before accepting the event.",
+                "Receiver stores the full landmark.release-kit.v1 JSON body, including text-floor evidence artifacts."
+            ],
+            "evidence_path": if receipt_file.as_os_str().is_empty() {
+                ".landmark/run/producers/release-feed-receiver.json".to_string()
+            } else {
+                receipt_file.display().to_string()
+            }
+        }),
+    )?;
+    Ok(())
+}
+
+fn sha256_json(value: &Value) -> Result<String> {
+    Ok(sha256_hex(&serde_json::to_vec(value)?))
+}
+
+fn upsert_artifact(release_kit: &mut Value, artifact: Value) -> Result<()> {
+    upsert_object_by_key(release_kit, "/artifacts", "id", artifact)
+}
+
+fn upsert_provenance(release_kit: &mut Value, provenance: Value) -> Result<()> {
+    upsert_object_by_key(release_kit, "/provenance", "artifact_id", provenance)
+}
+
+fn upsert_approval(release_kit: &mut Value, approval: Value) -> Result<()> {
+    upsert_object_by_key(release_kit, "/approvals", "artifact_id", approval)
+}
+
+fn upsert_producer_contract(release_kit: &mut Value, contract: Value) -> Result<()> {
+    upsert_object_by_key(release_kit, "/producer_contracts", "id", contract)
+}
+
+fn upsert_object_by_key(
+    release_kit: &mut Value,
+    pointer: &str,
+    key: &str,
+    replacement: Value,
+) -> Result<()> {
+    let id = replacement[key]
+        .as_str()
+        .ok_or_else(|| format!("replacement missing {key}"))?
+        .to_string();
+    let items = release_kit
+        .pointer_mut(pointer)
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| format!("release kit missing array at {pointer}"))?;
+    if let Some(existing) = items
+        .iter_mut()
+        .find(|item| item[key].as_str() == Some(id.as_str()))
+    {
+        *existing = replacement;
+    } else {
+        items.push(replacement);
+    }
+    Ok(())
+}
+
+fn post_release_feed_event(url: &str, signature: &str, body: &str) -> Result<HttpResponse> {
+    let mut last_error = String::new();
+    for attempt in 1..=3 {
+        match post_release_feed_event_once(url, signature, body) {
+            Ok(response) if !http_status_retryable(response.status) || attempt == 3 => {
+                return Ok(response);
+            }
+            Ok(response) => {
+                last_error = format!("HTTP {}", response.status);
+            }
+            Err(error) if attempt == 3 => return Err(error),
+            Err(error) => {
+                last_error = error.to_string();
+            }
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+    Err(last_error.into())
+}
+
+fn post_release_feed_event_once(url: &str, signature: &str, body: &str) -> Result<HttpResponse> {
+    let mut config = String::new();
+    push_curl_config(&mut config, "request", "POST");
+    push_curl_config(&mut config, "header", "Accept: application/json");
+    push_curl_config(&mut config, "header", "Content-Type: application/json");
+    push_curl_config(&mut config, "header", "User-Agent: landmark");
+    push_curl_config(
+        &mut config,
+        "header",
+        &format!("{SIGNATURE_HEADER}: {signature}"),
+    );
+    push_curl_config(&mut config, "write-out", "\n%{http_code}");
+    push_curl_config(&mut config, "url", url);
+    push_curl_config(&mut config, "data-binary", body);
+    let mut child = Command::new("curl")
+        .args([
+            "-sS",
+            "-L",
+            "--connect-timeout",
+            "5",
+            "--max-time",
+            "30",
+            "-K",
+            "-",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .ok_or("failed to open curl stdin")?
+        .write_all(config.as_bytes())?;
+    let output = child.wait_with_output()?;
+    if !output.status.success() {
+        return Err(redact_known_secrets(&String::from_utf8_lossy(&output.stderr)).into());
+    }
+    let raw = String::from_utf8(output.stdout)?;
+    let (body, status) = raw
+        .trim_end()
+        .rsplit_once('\n')
+        .ok_or("curl status marker missing")?;
+    Ok(HttpResponse {
+        status: status.parse()?,
+        body: body.to_string(),
+    })
+}

--- a/crates/landmark/src/release_ops/mod.rs
+++ b/crates/landmark/src/release_ops/mod.rs
@@ -1,11 +1,13 @@
 mod artifacts;
 mod backfill;
 mod contracts;
+mod feed_adapter;
 mod models;
 mod run;
 
 pub(crate) use artifacts::*;
 pub(crate) use backfill::*;
 pub(crate) use contracts::*;
+pub(crate) use feed_adapter::*;
 pub(crate) use models::*;
 pub(crate) use run::*;

--- a/crates/landmark/src/release_ops/models.rs
+++ b/crates/landmark/src/release_ops/models.rs
@@ -196,6 +196,7 @@ pub(crate) struct RunEvidence {
     pub(crate) technical_changelog_sha256: String,
     pub(crate) notes_sha256: String,
     pub(crate) version_decision: RunVersionDecision,
+    pub(crate) changed_files: Vec<String>,
     pub(crate) artifacts: RunArtifactRecord,
     pub(crate) release_kit: release_kit::ReleaseKit,
     pub(crate) publication: RunPublicationRecord,

--- a/crates/landmark/src/release_ops/run.rs
+++ b/crates/landmark/src/release_ops/run.rs
@@ -74,6 +74,7 @@ pub(crate) fn run_pipeline(args: RunArgs) -> Result<()> {
         technical_changelog_sha256: sha256_hex(technical_changelog.as_bytes()),
         notes_sha256: sha256_hex(notes.as_bytes()),
         version_decision: release.decision,
+        changed_files: context_changed_files(&args.repo_root, &release.version),
         artifacts,
         release_kit,
         publication,

--- a/crates/landmark/src/replay/contract_scenarios.rs
+++ b/crates/landmark/src/replay/contract_scenarios.rs
@@ -193,6 +193,10 @@ pub(crate) fn action_subcommand_replay_coverage() -> BTreeMap<&'static str, Vec<
             ],
         ),
         ("notify-webhook", vec!["http_resilience_policy"]),
+        (
+            "notify-release-feed",
+            vec!["release_feed_adapter", "http_resilience_policy"],
+        ),
         ("notify-slack", vec!["http_resilience_policy"]),
         ("floating-tag", vec!["consumer_floating_tag_behavior"]),
         (

--- a/crates/landmark/src/replay/mod.rs
+++ b/crates/landmark/src/replay/mod.rs
@@ -3,12 +3,14 @@ mod contract_scenarios;
 mod fake_server;
 mod fleet_scenarios;
 mod provider_scenarios;
+mod release_feed_scenarios;
 mod support;
 
 pub(crate) use contract_scenarios::*;
 pub(crate) use fake_server::*;
 pub(crate) use fleet_scenarios::*;
 pub(crate) use provider_scenarios::*;
+pub(crate) use release_feed_scenarios::*;
 pub(crate) use support::*;
 
 pub(crate) fn replay_action(args: ReplayArgs) -> Result<()> {
@@ -192,6 +194,10 @@ pub(crate) fn scenario_map() -> BTreeMap<String, Scenario> {
         scenario_action_side_effect_coverage,
     );
     map.insert(
+        "release_feed_adapter".to_string(),
+        scenario_release_feed_adapter,
+    );
+    map.insert(
         "synthesis-only-success".to_string(),
         scenario_consumer_synthesis_only_success,
     );
@@ -248,5 +254,6 @@ pub(crate) fn canonical_scenarios() -> Vec<&'static str> {
         "agent_native_contracts",
         "http_resilience_policy",
         "action_side_effect_coverage",
+        "release_feed_adapter",
     ]
 }

--- a/crates/landmark/src/replay/release_feed_scenarios.rs
+++ b/crates/landmark/src/replay/release_feed_scenarios.rs
@@ -1,0 +1,192 @@
+use crate::*;
+
+pub(crate) fn scenario_release_feed_adapter(tmp_root: &Path) -> Result<Value> {
+    let repo = tmp_root.join("release-feed-adapter");
+    let run_dir = repo.join(".landmark/run");
+    fs::create_dir_all(&run_dir)?;
+    let technical_path = run_dir.join("technical-changelog.md");
+    fs::write(
+        &technical_path,
+        "## Technical Changelog v1.2.3\n\n- feat(feed): publish release evidence (abc1234)\n",
+    )?;
+    let technical_sha = sha256_hex(&fs::read(&technical_path)?);
+    let release_kit_path = run_dir.join("release-kit.json");
+    let evidence_path = run_dir.join("evidence.json");
+    let version_decision = json!({
+        "latest_tag": "v1.2.2",
+        "bump": "minor",
+        "commit_count": 1,
+        "conventional_commit_count": 1,
+        "range": "v1.2.2..HEAD",
+        "decisive_commit": "feat(feed): publish release evidence (abc1234)",
+        "unknown_commits": []
+    });
+    let release_kit = json!({
+        "schema_version": "landmark.release-kit.v1",
+        "generated_at": "2026-07-03T12:00:00Z",
+        "product": {"name": "Landmark", "repository": "misty-step/landmark", "audience": "developer", "description": "Release intelligence"},
+        "release": {
+            "tag": "v1.2.3",
+            "version": "1.2.3",
+            "previous_tag": "v1.2.2",
+            "repository": "misty-step/landmark",
+            "release_url": "https://github.com/misty-step/landmark/releases/tag/v1.2.3",
+            "version_decision": version_decision
+        },
+        "classification": {"importance": "medium", "audiences": ["developer"], "why_it_matters": "release feed evidence"},
+        "artifacts": [
+            {
+                "id": "technical-changelog",
+                "kind": "technical_changelog",
+                "audience": "developer-operator",
+                "owner": "landmark",
+                "status": "produced",
+                "path": technical_path.display().to_string(),
+                "sha256": technical_sha,
+                "acceptance": ["Preserves raw commit subjects."]
+            },
+            {
+                "id": "release-notes",
+                "kind": "release_notes",
+                "audience": "developer",
+                "owner": "landmark",
+                "status": "produced",
+                "path": "docs/releases/v1.2.3.md",
+                "sha256": "notes-sha",
+                "acceptance": ["Summarizes the release."]
+            }
+        ],
+        "producer_contracts": [],
+        "provenance": [
+            {"artifact_id": "technical-changelog", "sources": ["git:v1.2.2..HEAD"]},
+            {"artifact_id": "release-notes", "sources": ["git:v1.2.2..HEAD"]}
+        ],
+        "approvals": [
+            {"artifact_id": "technical-changelog", "state": "not-required"},
+            {"artifact_id": "release-notes", "state": "not-required"}
+        ],
+        "status": {"complete": true, "blocked": false, "summary": "fixture kit"}
+    });
+    let evidence = json!({
+        "provider": "github",
+        "generated_at": "2026-07-03T12:00:00Z",
+        "repo_root": repo.display().to_string(),
+        "repository": "misty-step/landmark",
+        "release_tag": "v1.2.3",
+        "version": "1.2.3",
+        "previous_tag": "v1.2.2",
+        "source": "git_range",
+        "technical_changelog_sha256": technical_sha,
+        "notes_sha256": "notes-sha",
+        "version_decision": release_kit["release"]["version_decision"].clone(),
+        "changed_files": ["crates/landmark/src/release_ops/feed_adapter.rs"],
+        "artifacts": {
+            "technical_changelog": technical_path.display().to_string(),
+            "technical_changelog_audience": "internal-developer-operator",
+            "technical_changelog_schema": "landmark.internal-technical-changelog.v1",
+            "markdown": "docs/releases/v1.2.3.md",
+            "public_notes_audience": "developer",
+            "public_notes_schema": "landmark.public-release-notes.v1",
+            "plaintext": "docs/releases/v1.2.3.txt",
+            "html": "docs/releases/v1.2.3.html",
+            "json": "docs/releases/releases.json",
+            "rss": "",
+            "evidence": evidence_path.display().to_string(),
+            "release_kit": release_kit_path.display().to_string(),
+            "release_kit_schema": "landmark.release-kit.v1",
+            "release_kit_sha256": "kit-sha"
+        },
+        "release_kit": release_kit,
+        "publication": {
+            "provider": "github",
+            "enabled": true,
+            "release_body_updated": true,
+            "release_url": "https://github.com/misty-step/landmark/releases/tag/v1.2.3",
+            "status": "updated"
+        }
+    });
+    fs::write(
+        &release_kit_path,
+        serde_json::to_string_pretty(&evidence["release_kit"])? + "\n",
+    )?;
+    fs::write(
+        &evidence_path,
+        serde_json::to_string_pretty(&evidence)? + "\n",
+    )?;
+
+    let receiver = start_replay_release_feed_receiver("feed-secret")?;
+    let receipt_file = run_dir.join("release-feed-receipt.json");
+    notify_release_feed_receipt(NotifyReleaseFeedArgs {
+        receiver_url: receiver.url,
+        receiver_secret: "feed-secret".into(),
+        evidence_file: evidence_path,
+        release_kit_file: release_kit_path,
+        receipt_file: receipt_file.clone(),
+    })?;
+    let payload = receiver
+        .payload
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or("release feed replay receiver did not capture payload")?;
+    let artifact_ids: BTreeSet<String> = payload["artifacts"]
+        .as_array()
+        .ok_or("release feed payload missing artifacts")?
+        .iter()
+        .filter_map(|artifact| artifact["id"].as_str().map(str::to_string))
+        .collect();
+    for id in ["version-decision", "changed-files", "changelog-diff"] {
+        if !artifact_ids.contains(id) {
+            return Err(format!("release feed payload missing {id}").into());
+        }
+    }
+    Ok(json!({
+        "posted": true,
+        "receipt": receipt_file,
+        "artifact_ids": artifact_ids,
+    }))
+}
+
+struct ReplayReleaseFeedReceiver {
+    url: String,
+    payload: Arc<Mutex<Option<Value>>>,
+}
+
+fn start_replay_release_feed_receiver(secret: &'static str) -> Result<ReplayReleaseFeedReceiver> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let addr = listener.local_addr()?;
+    let server =
+        tiny_http::Server::from_listener(listener, None).map_err(|error| error.to_string())?;
+    let payload = Arc::new(Mutex::new(None));
+    let thread_payload = Arc::clone(&payload);
+    thread::spawn(move || {
+        if let Some(mut request) = server.incoming_requests().next() {
+            let signature = request
+                .headers()
+                .iter()
+                .find(|header| header.field.equiv("X-Signature-256"))
+                .map(|header| header.value.as_str().to_string())
+                .unwrap_or_default();
+            let mut body = String::new();
+            let _ = request.as_reader().read_to_string(&mut body);
+            let expected = compute_signature(secret, body.as_bytes()).unwrap_or_default();
+            let parsed: Value = serde_json::from_str(&body).unwrap_or_else(|_| json!({}));
+            let status = if request.method() == &tiny_http::Method::Post
+                && request.url() == "/v1/events"
+                && signature == expected
+                && parsed["schema_version"] == release_kit::SCHEMA_VERSION
+            {
+                *thread_payload.lock().unwrap() = Some(parsed);
+                202
+            } else {
+                400
+            };
+            let _ = request.respond(json_response(status, json!({})));
+        }
+    });
+    thread::sleep(Duration::from_millis(50));
+    Ok(ReplayReleaseFeedReceiver {
+        url: format!("http://{addr}/v1/events"),
+        payload,
+    })
+}

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -37,7 +37,9 @@ landmark run --provider local --repo-root . --dry-run
 plan, and embedded `release_kit` without writing artifacts or mutating a remote
 release. A normal local run writes the same release-kit artifact to
 `.landmark/run/release-kit.json` and records its schema and hash in
-`.landmark/run/evidence.json`.
+`.landmark/run/evidence.json`. The evidence packet also carries the
+deterministic version decision and changed-file list for producer adapters that
+need text evidence without re-reading the repository.
 
 For a GitHub-backed pipeline, keep publication explicit:
 
@@ -95,6 +97,21 @@ or browser-capture pipelines in the core runtime. Route those through producer
 adapters such as local CLIs, browser automation, external services, harness
 skills, or human approval. Producers consume release-kit inputs and return
 artifact paths, hashes, evidence, and status.
+
+The remote-service feed adapter is:
+
+```bash
+landmark notify-release-feed \
+  --evidence-file .landmark/run/evidence.json \
+  --release-kit-file .landmark/run/release-kit.json
+```
+
+It reads `RELEASE_FEED_URL` and `RELEASE_FEED_SECRET` from the environment
+(`LANDMARK_RELEASE_FEED_*` and `RELEASE_KIT_FEED_*` aliases are also accepted),
+enriches the kit with produced text-floor artifacts, and POSTs the full
+`landmark.release-kit.v1` JSON body to `POST /v1/events`. The request signature
+matches Landmark's webhook scheme: `X-Signature-256: sha256=<hmac>` over the raw
+body. Missing receiver config is a clean skip.
 
 Typical release-kit artifacts include migration guides, docs patches, blog
 drafts, essays, announcement copy, social copy, screenshots, images, GIFs, demo

--- a/docs/fleet-integration-playbook.md
+++ b/docs/fleet-integration-playbook.md
@@ -169,6 +169,11 @@ GitHub workflows need:
 - `OPENROUTER_API_KEY`: LLM synthesis. Missing or stale keys should not block
   release unless the repo deliberately sets `synthesis-required: "true"`.
 
+Optional release-kit feed delivery uses `RELEASE_FEED_URL` and
+`RELEASE_FEED_SECRET`. When either is missing, `landmark notify-release-feed`
+skips cleanly; when both are present, it signs the full release-kit JSON with
+`X-Signature-256` and POSTs it to `/v1/events`.
+
 Declare `contents: write`, `issues: write`, and `pull-requests: write`.
 
 ## Verification

--- a/schemas/run-evidence.v1.schema.json
+++ b/schemas/run-evidence.v1.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "additionalProperties": false,
   "x-landmark-artifact": "landmark run evidence packet",
-  "required": ["provider", "generated_at", "repo_root", "repository", "release_tag", "version", "previous_tag", "source", "technical_changelog_sha256", "notes_sha256", "version_decision", "artifacts", "release_kit", "publication"],
+  "required": ["provider", "generated_at", "repo_root", "repository", "release_tag", "version", "previous_tag", "source", "technical_changelog_sha256", "notes_sha256", "version_decision", "changed_files", "artifacts", "release_kit", "publication"],
   "properties": {
     "provider": { "type": "string", "enum": ["local", "github"] },
     "generated_at": { "type": "string" },
@@ -30,6 +30,10 @@
         "unknown_commits": { "type": "array", "items": { "type": "string" } }
       },
       "additionalProperties": false
+    },
+    "changed_files": {
+      "type": "array",
+      "items": { "type": "string" }
     },
     "artifacts": {
       "type": "object",


### PR DESCRIPTION
## Summary
- add `landmark notify-release-feed`, a remote-service producer adapter that enriches release-kit JSON with produced text-floor artifacts (`version-decision`, `changed-files`, `changelog-diff`)
- sign `POST /v1/events` with the existing Landmark webhook scheme: `X-Signature-256: sha256=<hmac>` over the raw release-kit body
- wire the adapter as an optional post-synthesis action step and dogfood it from Landmark self-release when `RELEASE_FEED_URL`/`RELEASE_FEED_SECRET` are configured

## Verification
- `cargo test --locked -p landmark notify_release_feed_posts_signed_release_kit_with_text_floor_artifacts`
- `cargo run --locked -- replay-action --scenario release_feed_adapter --format json`
- `cargo run --locked -- check-action-contract`
- `cargo run --locked -- replay-action --scenario agent_native_contracts --scenario action_side_effect_coverage --format json`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- `bin/gate`

## Receiver Contract
- URL env: `RELEASE_FEED_URL`; aliases: `LANDMARK_RELEASE_FEED_URL`, `RELEASE_KIT_FEED_URL`
- secret env: `RELEASE_FEED_SECRET`; aliases: `LANDMARK_RELEASE_FEED_SECRET`, `RELEASE_KIT_FEED_SECRET`
- missing URL or secret is a clean skip
- receiver must validate `X-Signature-256` exactly as Landmark `notify-webhook` does (`sha256=<hex hmac>`) against the raw JSON body before accepting the event

Agent: Codex
Agent-Surface: Codex CLI
Agent-Runner: codex
Agent-Model: GPT-5
Agent-Task: release intelligence feed adapter
