### PR TITLE
chore(release): send Landmark webhook to Weave receiver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -216,3 +216,5 @@ jobs:
           synthesis-required: "false"
           floating-tags: "true"
           changelog-source: release-body
+          webhook-url: ${{ secrets.LANDMARK_WEBHOOK_URL }}
+          webhook-secret: ${{ secrets.LANDMARK_WEBHOOK_SECRET }}


### PR DESCRIPTION
## Summary

Wires Landmark's own release workflow to the shared Weave release-event receiver.

The workflow now passes:

- `webhook-url: ${{ secrets.LANDMARK_WEBHOOK_URL }}`
- `webhook-secret: ${{ secrets.LANDMARK_WEBHOOK_SECRET }}`

Secrets have already been set on `misty-step/landmark`; values are intentionally not included here.

## Validation

- `bin/gate`

No release was cut for this test; receiver behavior was verified with a synthetic signed POST against the deployed Weave app.
