### PR TITLE
fix(release): unify synthesis grounding

### DIFF
--- a/crates/landmark/src/classification_tests.rs
+++ b/crates/landmark/src/classification_tests.rs
@@ -222,7 +222,16 @@ fn dry_run_context_packet_does_not_call_model_classifier() {
     args.api_url = format!("{}/chat/completions", server.url);
     args.dry_run_cost = true;
 
-    let context = synthesis_context_packet_with_model(&args, &config, &technical, "prompt");
+    let grounding = ReleaseGrounding {
+        technical_changelog: technical,
+        deterministic: deterministic_release_context(&args, &config),
+        metadata: ReleaseGroundingMetadata {
+            selected_source: "test".into(),
+            selected_source_status: "matched".into(),
+            ..Default::default()
+        },
+    };
+    let context = synthesis_context_packet_with_model(&args, &config, &grounding, "prompt");
 
     assert_eq!(context.classification.source, "structured");
     assert!(server.state.lock().unwrap().requests.is_empty());

--- a/crates/landmark/src/main.rs
+++ b/crates/landmark/src/main.rs
@@ -33,6 +33,7 @@ mod release_body;
 mod release_classification;
 #[cfg(test)]
 mod release_feed_tests;
+mod release_grounding;
 mod release_kit;
 mod release_kit_contract;
 #[cfg(test)]
@@ -59,6 +60,7 @@ pub(crate) use pr_range::*;
 pub(crate) use providers::*;
 pub(crate) use release_body::*;
 pub(crate) use release_classification::*;
+pub(crate) use release_grounding::*;
 pub(crate) use release_ops::*;
 pub(crate) use replay::*;
 pub(crate) use self_release::*;

--- a/crates/landmark/src/manifest.rs
+++ b/crates/landmark/src/manifest.rs
@@ -77,6 +77,7 @@ pub(crate) struct EffectiveSynthesisConfig {
 pub(crate) struct SynthesisContextPacket {
     pub(crate) product: ContextProduct,
     pub(crate) release: ContextRelease,
+    pub(crate) grounding: ReleaseGroundingMetadata,
     pub(crate) deterministic: DeterministicReleaseContext,
     pub(crate) sources: Vec<ContextSource>,
     pub(crate) classification: ReleaseClassification,
@@ -96,6 +97,18 @@ pub(crate) struct ContextRelease {
     pub(crate) version: String,
     pub(crate) changelog_source: String,
     pub(crate) model_policy: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct ReleaseGroundingMetadata {
+    pub(crate) selected_source: String,
+    pub(crate) selected_source_status: String,
+    pub(crate) warnings: Vec<String>,
+    pub(crate) commit_count: usize,
+    pub(crate) diff_stat_count: usize,
+    pub(crate) changelog_section: ContextOptionalSource,
+    pub(crate) release_body: ContextOptionalSource,
+    pub(crate) pull_requests: ContextOptionalSource,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/crates/landmark/src/release_grounding.rs
+++ b/crates/landmark/src/release_grounding.rs
@@ -1,0 +1,244 @@
+use crate::*;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ReleaseGrounding {
+    pub(crate) technical_changelog: String,
+    pub(crate) deterministic: DeterministicReleaseContext,
+    pub(crate) metadata: ReleaseGroundingMetadata,
+}
+
+#[derive(Clone, Debug)]
+struct GroundingCandidate {
+    source: &'static str,
+    text: String,
+    agrees_with_commits: bool,
+}
+
+pub(crate) fn resolve_release_grounding(
+    args: &SynthesizeArgs,
+    config: &EffectiveSynthesisConfig,
+) -> Result<ReleaseGrounding> {
+    let deterministic = deterministic_release_context(args, config);
+    let (changelog_section, changelog_missing_section) =
+        resolve_changelog_section(&args.changelog_file, &args.version)?;
+    let release_body = read_optional_file(&args.release_body_file)?;
+    let pull_requests = read_optional_file(&args.pr_changelog_file)?;
+    let candidates = grounding_candidates(
+        &deterministic,
+        &changelog_section,
+        &release_body,
+        &pull_requests,
+    );
+    let source = config.changelog_source.to_ascii_lowercase();
+    let mut warnings = Vec::new();
+    if changelog_missing_section {
+        warnings.push(format!(
+            "CHANGELOG.md has no section for {}; the release commit range is authoritative",
+            args.version
+        ));
+    }
+
+    let selected = match source.as_str() {
+        "auto" => {
+            let selected = candidates
+                .iter()
+                .find(|candidate| candidate.agrees_with_commits)
+                .cloned();
+            if selected.is_none() {
+                for candidate in candidates.iter().filter(|candidate| {
+                    !candidate.agrees_with_commits && !deterministic.commits.is_empty()
+                }) {
+                    warnings.push(format!(
+                        "auto {} source did not match release commits; using the git range as ground truth",
+                        candidate.source
+                    ));
+                }
+            }
+            selected
+        }
+        "changelog" | "release-body" | "prs" => Some(
+            // Explicit overrides are operator intent, so keep the requested
+            // source visible even when it mismatches. The warning and commit
+            // list make the conflict reviewable instead of silently guessing.
+            candidates
+                .iter()
+                .find(|candidate| candidate.source == source)
+                .cloned()
+                .ok_or_else(|| required_source_error(&source, args))?,
+        ),
+        _ => return Err(format!("invalid changelog-source {source}").into()),
+    };
+
+    if let Some(candidate) = &selected
+        && !candidate.agrees_with_commits
+        && !deterministic.commits.is_empty()
+    {
+        warnings.push(format!(
+            "selected {} source does not match release commits; prefer the commit list below",
+            candidate.source
+        ));
+    }
+
+    let selected_source = selected
+        .as_ref()
+        .map(|candidate| candidate.source.to_string())
+        .unwrap_or_else(|| "git-range".into());
+    let selected_source_status = selected
+        .as_ref()
+        .map(|candidate| {
+            if candidate.agrees_with_commits {
+                "matched"
+            } else {
+                "mismatched"
+            }
+        })
+        .unwrap_or("commit-range")
+        .to_string();
+    let metadata = ReleaseGroundingMetadata {
+        selected_source,
+        selected_source_status,
+        warnings: warnings.clone(),
+        commit_count: deterministic.commits.len(),
+        diff_stat_count: deterministic.diff_stats.len(),
+        changelog_section: optional_source_summary(changelog_section.as_deref()),
+        release_body: optional_source_summary(release_body.as_deref()),
+        pull_requests: optional_source_summary(pull_requests.as_deref()),
+    };
+    let technical_changelog =
+        render_grounded_technical_changelog(args, &deterministic, selected.as_ref(), &warnings);
+
+    Ok(ReleaseGrounding {
+        technical_changelog,
+        deterministic,
+        metadata,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn resolve_technical_changelog(
+    args: &SynthesizeArgs,
+    config: &EffectiveSynthesisConfig,
+) -> Result<String> {
+    Ok(resolve_release_grounding(args, config)?.technical_changelog)
+}
+
+fn resolve_changelog_section(path: &Path, version: &str) -> Result<(Option<String>, bool)> {
+    if !path.is_file() {
+        return Ok((None, false));
+    }
+    let text = fs::read_to_string(path)?;
+    if text.trim().is_empty() {
+        return Ok((None, false));
+    }
+    let section = extract_release_section(&text, version);
+    let missing_section = section.is_none();
+    Ok((section, missing_section))
+}
+
+fn grounding_candidates(
+    deterministic: &DeterministicReleaseContext,
+    changelog_section: &Option<String>,
+    release_body: &Option<String>,
+    pull_requests: &Option<String>,
+) -> Vec<GroundingCandidate> {
+    [
+        ("changelog", changelog_section),
+        ("release-body", release_body),
+        ("prs", pull_requests),
+    ]
+    .into_iter()
+    .filter_map(|(source, text)| {
+        let text = text.as_ref()?;
+        Some(GroundingCandidate {
+            source,
+            text: text.clone(),
+            agrees_with_commits: source_agrees_with_commits(text, deterministic),
+        })
+    })
+    .collect()
+}
+
+fn source_agrees_with_commits(text: &str, deterministic: &DeterministicReleaseContext) -> bool {
+    deterministic.commits.is_empty() || !release_relevant_commits(text, deterministic).is_empty()
+}
+
+fn required_source_error(source: &str, args: &SynthesizeArgs) -> String {
+    match source {
+        "changelog" => format!(
+            "CHANGELOG.md is missing, empty, or has no section for {}",
+            args.version
+        ),
+        "release-body" => "release body source is missing or empty".into(),
+        "prs" => "PR changelog source is missing or empty".into(),
+        _ => format!("invalid changelog-source {source}"),
+    }
+}
+
+fn optional_source_summary(text: Option<&str>) -> ContextOptionalSource {
+    ContextOptionalSource {
+        present: text.is_some_and(|text| !text.trim().is_empty()),
+        estimated_tokens: text.map(estimate_tokens).unwrap_or(0),
+    }
+}
+
+fn render_grounded_technical_changelog(
+    args: &SynthesizeArgs,
+    deterministic: &DeterministicReleaseContext,
+    selected: Option<&GroundingCandidate>,
+    warnings: &[String],
+) -> String {
+    let mut rendered = format!("Release-scoped ground truth for {}\n\n", args.version);
+    if !warnings.is_empty() {
+        rendered.push_str("Grounding warnings:\n");
+        for warning in warnings {
+            rendered.push_str(&format!("- {warning}\n"));
+        }
+        rendered.push('\n');
+    }
+    rendered.push_str("Release commits (authoritative):\n");
+    if deterministic.commits.is_empty() {
+        rendered.push_str("- No release commits found in the resolved git range.\n");
+    } else {
+        for commit in &deterministic.commits {
+            rendered.push_str(&format!("- {}", commit.subject));
+            if !commit.short_hash.trim().is_empty() {
+                rendered.push_str(&format!(" ({})", commit.short_hash));
+            }
+            rendered.push('\n');
+            for line in commit
+                .body
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+            {
+                rendered.push_str(&format!("  {line}\n"));
+            }
+        }
+    }
+    rendered.push('\n');
+    rendered.push_str("Diff stats:\n");
+    if deterministic.diff_stats.is_empty() {
+        rendered.push_str("- No file-level diff stats recorded.\n");
+    } else {
+        for stat in deterministic.diff_stats.iter().take(20) {
+            rendered.push_str(&format!(
+                "- {} (+{} -{})\n",
+                stat.path, stat.additions, stat.deletions
+            ));
+        }
+    }
+    if let Some(candidate) = selected {
+        rendered.push('\n');
+        rendered.push_str(&format!(
+            "Selected technical source ({}; {}):\n\n{}\n",
+            candidate.source,
+            if candidate.agrees_with_commits {
+                "matched release commits"
+            } else {
+                "does not match release commits"
+            },
+            candidate.text.trim()
+        ));
+    }
+    rendered.trim().to_string()
+}

--- a/crates/landmark/src/replay/mod.rs
+++ b/crates/landmark/src/replay/mod.rs
@@ -142,6 +142,10 @@ pub(crate) fn scenario_map() -> BTreeMap<String, Scenario> {
         scenario_release_kit_classification_uses_structured_commits,
     );
     map.insert(
+        "release_grounding_unified_path".to_string(),
+        scenario_release_grounding_unified_path,
+    );
+    map.insert(
         "first_run_local_preview".to_string(),
         scenario_first_run_local_preview,
     );
@@ -236,6 +240,7 @@ pub(crate) fn canonical_scenarios() -> Vec<&'static str> {
         "github_provider_run",
         "local_provider_run",
         "release_kit_classification_uses_structured_commits",
+        "release_grounding_unified_path",
         "provider_run_parity",
         "manifest_defaults_and_overrides",
         "consumer_release_update_failure",

--- a/crates/landmark/src/replay/provider_scenarios/grounding.rs
+++ b/crates/landmark/src/replay/provider_scenarios/grounding.rs
@@ -1,0 +1,125 @@
+use crate::*;
+
+pub(crate) fn scenario_release_grounding_unified_path(tmp_root: &Path) -> Result<Value> {
+    let repo = tmp_root.join("release-grounding-unified-path");
+    init_fixture_repo(&repo, "v1.0.0")?;
+    fs::write(repo.join("release.txt"), "recover canary check-ins\n")?;
+    run_ok("git", ["add", "release.txt"], &repo)?;
+    run_ok(
+        "git",
+        ["commit", "-q", "-m", "fix: recover canary check-ins"],
+        &repo,
+    )?;
+    run_ok("git", ["tag", "v1.1.0"], &repo)?;
+
+    fs::write(
+        repo.join("CHANGELOG.md"),
+        "## [0.9.0]\n\n- feat: stale dashboard rewrite\n",
+    )?;
+    fs::write(
+        repo.join("pr-changelog.md"),
+        "- ancient unrelated dashboard rewrite (#41) by @octocat\n",
+    )?;
+    fs::write(
+        repo.join(".landmark.yml"),
+        r#"product:
+  name: Grounding Demo
+  description: Release grounding replay.
+model:
+  policy: cheap
+"#,
+    )?;
+
+    let mut fake = FakeState {
+        llm_status: 200,
+        update_status: 200,
+        ..Default::default()
+    };
+    fake.llm_responses.push_back((
+        200,
+        json!({
+            "categories": ["user-visible"],
+            "significance": "medium",
+            "user_visible": true,
+            "breaking": false,
+            "security": false,
+            "migration_heavy": false,
+            "reasons": ["release commit is a user-visible fix"]
+        })
+        .to_string(),
+    ));
+    fake.llm_responses.push_back((200, VALID_NOTES.to_string()));
+    let server = start_fake_server(fake)?;
+    let context_file = repo.join("context.json");
+    let quality_file = repo.join("quality.txt");
+    let templates_dir = env::current_dir()?.join("templates/prompts");
+    let result = Command::new(current_exe())
+        .args([
+            "synthesize",
+            "--api-key",
+            "test-key",
+            "--api-url",
+            &format!("{}/chat/completions", server.url),
+            "--version",
+            "v1.1.0",
+            "--changelog-file",
+            "CHANGELOG.md",
+            "--pr-changelog-file",
+            "pr-changelog.md",
+            "--templates-dir",
+        ])
+        .arg(&templates_dir)
+        .args(["--quality-file"])
+        .arg(&quality_file)
+        .args(["--context-metadata-file"])
+        .arg(&context_file)
+        .args(["--repo-root"])
+        .arg(&repo)
+        .current_dir(&repo)
+        .output()?;
+    if !result.status.success() {
+        return Err(String::from_utf8_lossy(&result.stderr).to_string().into());
+    }
+
+    let requests = server.state.lock().unwrap().requests.clone();
+    let synthesis_request = request_payloads_with_system(&requests, "release notes")?
+        .into_iter()
+        .next()
+        .ok_or("grounding replay did not send a synthesis request")?;
+    let prompt = synthesis_request["messages"][1]["content"]
+        .as_str()
+        .unwrap_or_default();
+    if !prompt.contains("fix: recover canary check-ins") {
+        return Err(format!("synthesis prompt missed release commit:\n{prompt}").into());
+    }
+    if prompt.contains("stale dashboard rewrite")
+        || prompt.contains("ancient unrelated dashboard rewrite")
+    {
+        return Err(format!("synthesis prompt included stale grounding text:\n{prompt}").into());
+    }
+    if !prompt.contains("Grounding rule:") {
+        return Err("synthesis prompt did not include the grounding rule".into());
+    }
+
+    let context: Value = serde_json::from_str(&fs::read_to_string(&context_file)?)?;
+    if context["grounding"]["selected_source"] != "git-range"
+        || context["grounding"]["selected_source_status"] != "commit-range"
+        || context["grounding"]["warnings"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .is_empty()
+    {
+        return Err(format!(
+            "context did not record git-range grounding fallback: {}",
+            context["grounding"]
+        )
+        .into());
+    }
+
+    Ok(json!({
+        "selected_source": context["grounding"]["selected_source"],
+        "selected_source_status": context["grounding"]["selected_source_status"],
+        "warning_count": context["grounding"]["warnings"].as_array().map(Vec::len).unwrap_or(0),
+        "quality": fs::read_to_string(quality_file)?.trim(),
+    }))
+}

--- a/crates/landmark/src/replay/provider_scenarios/mod.rs
+++ b/crates/landmark/src/replay/provider_scenarios/mod.rs
@@ -1,6 +1,7 @@
 use crate::*;
 mod consumers;
 mod failures;
+mod grounding;
 mod pr_pagination;
 mod pr_scoping;
 mod provider_runs;
@@ -10,6 +11,7 @@ mod synthesis_cost;
 
 pub(crate) use consumers::*;
 pub(crate) use failures::*;
+pub(crate) use grounding::*;
 pub(crate) use pr_pagination::*;
 pub(crate) use pr_scoping::*;
 pub(crate) use provider_runs::*;

--- a/crates/landmark/src/replay/provider_scenarios/synthesis_cost.rs
+++ b/crates/landmark/src/replay/provider_scenarios/synthesis_cost.rs
@@ -13,9 +13,16 @@ model:
   policy: balanced
 "#,
     )?;
+    fs::write(repo.join("README.md"), "# Fixture\n\nDocs refresh.\n")?;
+    run_ok("git", ["add", "README.md"], &repo)?;
+    run_ok(
+        "git",
+        ["commit", "-q", "-m", "docs: update README.md"],
+        &repo,
+    )?;
     fs::write(
         repo.join("CHANGELOG.md"),
-        "## [1.2.3]\n\n- docs: update README.md\n",
+        "## [1.2.4]\n\n- docs: update README.md\n",
     )?;
     let dry_run = Command::new(current_exe())
         .args([
@@ -25,7 +32,7 @@ model:
             "--api-url",
             "http://127.0.0.1:1/chat/completions",
             "--version",
-            "v1.2.3",
+            "v1.2.4",
             "--changelog-file",
             "CHANGELOG.md",
             "--templates-dir",
@@ -305,8 +312,25 @@ model:
 "#,
     )?;
     fs::write(
+        repo.join("security.txt"),
+        "tokens moved to a new manifest field\n",
+    )?;
+    run_ok("git", ["add", "security.txt"], &repo)?;
+    run_ok(
+        "git",
+        [
+            "commit",
+            "-q",
+            "-m",
+            "feat(api)!: rotate security-sensitive release token configuration",
+            "-m",
+            "BREAKING CHANGE: tokens moved to a new manifest field.",
+        ],
+        &repo,
+    )?;
+    fs::write(
         repo.join("CHANGELOG.md"),
-        "## [1.2.3]\n\n- feat(api)!: rotate security-sensitive release token configuration\n\nBREAKING CHANGE: tokens moved to a new manifest field.\n",
+        "## [1.2.5]\n\n- feat(api)!: rotate security-sensitive release token configuration\n\nBREAKING CHANGE: tokens moved to a new manifest field.\n",
     )?;
     let rich = Command::new(current_exe())
         .args([
@@ -316,7 +340,7 @@ model:
             "--api-url",
             "http://127.0.0.1:1/chat/completions",
             "--version",
-            "v1.2.3",
+            "v1.2.5",
             "--changelog-file",
             "CHANGELOG.md",
             "--templates-dir",
@@ -356,7 +380,7 @@ model:
             "--api-url",
             "http://127.0.0.1:1/chat/completions",
             "--version",
-            "v1.2.3",
+            "v1.2.5",
             "--changelog-file",
             "CHANGELOG.md",
             "--templates-dir",
@@ -401,7 +425,7 @@ model:
             "--api-url",
             "http://127.0.0.1:1/chat/completions",
             "--version",
-            "v1.2.3",
+            "v1.2.5",
             "--changelog-file",
             "CHANGELOG.md",
             "--templates-dir",
@@ -449,7 +473,7 @@ model:
             "--api-url",
             &format!("{}/chat/completions", provider_failure_server.url),
             "--version",
-            "v1.2.3",
+            "v1.2.5",
             "--changelog-file",
             "CHANGELOG.md",
             "--templates-dir",

--- a/crates/landmark/src/synthesis.rs
+++ b/crates/landmark/src/synthesis.rs
@@ -101,12 +101,12 @@ pub(crate) fn extract_prs(args: ExtractPrsArgs) -> Result<()> {
 
 pub(crate) fn synthesize(args: SynthesizeArgs) -> Result<()> {
     let config = resolve_synthesis_config(&args)?;
-    let technical = resolve_technical_changelog(&args, &config)?;
-    let prompt = render_prompt(&args, &config, &technical)?;
+    let grounding = resolve_release_grounding(&args, &config)?;
+    let prompt = render_prompt(&args, &config, &grounding.technical_changelog)?;
     let context = if args.dry_run_cost {
-        synthesis_context_packet(&args, &config, &technical, &prompt)
+        synthesis_context_packet(&args, &config, &grounding, &prompt)
     } else {
-        synthesis_context_packet_with_model(&args, &config, &technical, &prompt)
+        synthesis_context_packet_with_model(&args, &config, &grounding, &prompt)
     };
     write_json_if_requested(&args.context_metadata_file, &context)?;
     if args.dry_run_cost {
@@ -308,43 +308,6 @@ pub(crate) fn default_model_for_tier(tier: &str) -> &'static str {
     }
 }
 
-pub(crate) fn resolve_technical_changelog(
-    args: &SynthesizeArgs,
-    config: &EffectiveSynthesisConfig,
-) -> Result<String> {
-    let source = config.changelog_source.to_ascii_lowercase();
-    let from_changelog = if args.changelog_file.is_file() {
-        let text = fs::read_to_string(&args.changelog_file)?;
-        if text.trim().is_empty() {
-            None
-        } else {
-            extract_release_section(&text, &args.version)
-        }
-    } else {
-        None
-    };
-    let from_release_body = read_optional_file(&args.release_body_file)?;
-    let from_prs = read_optional_file(&args.pr_changelog_file)?;
-    match source.as_str() {
-        "auto" => from_changelog
-            .or(from_release_body)
-            .or(from_prs)
-            .ok_or_else(|| "no changelog source found".into()),
-        "changelog" => from_changelog.ok_or_else(|| {
-            format!(
-                "CHANGELOG.md is missing, empty, or has no section for {}",
-                args.version
-            )
-            .into()
-        }),
-        "release-body" => {
-            from_release_body.ok_or_else(|| "release body source is missing or empty".into())
-        }
-        "prs" => from_prs.ok_or_else(|| "PR changelog source is missing or empty".into()),
-        _ => Err(format!("invalid changelog-source {source}").into()),
-    }
-}
-
 pub(crate) fn read_optional_file(path: &Path) -> Result<Option<String>> {
     if path.as_os_str().is_empty() || !path.is_file() {
         return Ok(None);
@@ -423,19 +386,21 @@ pub(crate) fn render_prompt(
 pub(crate) fn synthesis_context_packet(
     args: &SynthesizeArgs,
     config: &EffectiveSynthesisConfig,
-    technical: &str,
+    grounding: &ReleaseGrounding,
     prompt: &str,
 ) -> SynthesisContextPacket {
-    let sources = synthesis_context_sources(args, config, technical, prompt);
-    let deterministic = deterministic_release_context(args, config);
-    let classification =
-        classify_release_context_with_deterministic(technical, &sources, &deterministic);
+    let sources = synthesis_context_sources(args, config, grounding, prompt);
+    let classification = classify_release_context_with_deterministic(
+        &grounding.technical_changelog,
+        &sources,
+        &grounding.deterministic,
+    );
     synthesis_context_packet_from_classification(
         args,
         config,
         prompt,
         sources,
-        deterministic,
+        grounding,
         classification,
     )
 }
@@ -443,19 +408,18 @@ pub(crate) fn synthesis_context_packet(
 pub(crate) fn synthesis_context_packet_with_model(
     args: &SynthesizeArgs,
     config: &EffectiveSynthesisConfig,
-    technical: &str,
+    grounding: &ReleaseGrounding,
     prompt: &str,
 ) -> SynthesisContextPacket {
     if args.dry_run_cost {
-        return synthesis_context_packet(args, config, technical, prompt);
+        return synthesis_context_packet(args, config, grounding, prompt);
     }
-    let sources = synthesis_context_sources(args, config, technical, prompt);
-    let deterministic = deterministic_release_context(args, config);
+    let sources = synthesis_context_sources(args, config, grounding, prompt);
     let models = release_classification_models(config);
     let classification = classify_release_context_with_model(
-        technical,
+        &grounding.technical_changelog,
         &sources,
-        &deterministic,
+        &grounding.deterministic,
         &args.api_url,
         &args.api_key,
         &models,
@@ -465,7 +429,7 @@ pub(crate) fn synthesis_context_packet_with_model(
         config,
         prompt,
         sources,
-        deterministic,
+        grounding,
         classification,
     )
 }
@@ -475,7 +439,7 @@ pub(crate) fn synthesis_context_packet_from_classification(
     config: &EffectiveSynthesisConfig,
     prompt: &str,
     sources: Vec<ContextSource>,
-    deterministic: DeterministicReleaseContext,
+    grounding: &ReleaseGrounding,
     classification: ReleaseClassification,
 ) -> SynthesisContextPacket {
     let cost = estimate_synthesis_cost(config, prompt, &classification, &sources);
@@ -491,7 +455,8 @@ pub(crate) fn synthesis_context_packet_from_classification(
             changelog_source: config.changelog_source.clone(),
             model_policy: config.model_policy.clone(),
         },
-        deterministic,
+        grounding: grounding.metadata.clone(),
+        deterministic: grounding.deterministic.clone(),
         sources,
         classification,
         cost,
@@ -733,12 +698,16 @@ pub(crate) fn empty_git_tree() -> &'static str {
 pub(crate) fn synthesis_context_sources(
     args: &SynthesizeArgs,
     config: &EffectiveSynthesisConfig,
-    technical: &str,
+    grounding: &ReleaseGrounding,
     prompt: &str,
 ) -> Vec<ContextSource> {
     let mut sources = vec![
         context_source("prompt_template", "prompt", prompt),
-        context_source("technical_changelog", &config.changelog_source, technical),
+        context_source(
+            "technical_changelog",
+            &grounding.metadata.selected_source,
+            &grounding.technical_changelog,
+        ),
     ];
     if !config.product_description.trim().is_empty() {
         sources.push(context_source(
@@ -755,21 +724,40 @@ pub(crate) fn synthesis_context_sources(
         ));
     }
     if let Ok(Some(body)) = read_optional_file(&args.release_body_file) {
-        sources.push(context_source("release_body", "release-body", &body));
+        sources.push(context_source_with_included(
+            "release_body",
+            "release-body",
+            &body,
+            grounding.metadata.selected_source == "release-body",
+        ));
     }
     if let Ok(Some(prs)) = read_optional_file(&args.pr_changelog_file) {
-        sources.push(context_source("pull_requests", "prs", &prs));
+        sources.push(context_source_with_included(
+            "pull_requests",
+            "prs",
+            &prs,
+            grounding.metadata.selected_source == "prs",
+        ));
     }
     sources
 }
 
 pub(crate) fn context_source(name: &str, kind: &str, text: &str) -> ContextSource {
+    context_source_with_included(name, kind, text, !text.trim().is_empty())
+}
+
+pub(crate) fn context_source_with_included(
+    name: &str,
+    kind: &str,
+    text: &str,
+    included: bool,
+) -> ContextSource {
     ContextSource {
         name: name.to_string(),
         kind: kind.to_string(),
         bytes: text.len(),
         estimated_tokens: estimate_tokens(text),
-        included: !text.trim().is_empty(),
+        included: included && !text.trim().is_empty(),
     }
 }
 

--- a/crates/landmark/src/synthesis_tests.rs
+++ b/crates/landmark/src/synthesis_tests.rs
@@ -109,6 +109,79 @@ fn resolve_technical_changelog_explicit_changelog_source_fails_loudly_on_missing
 }
 
 #[test]
+fn resolve_technical_changelog_auto_uses_release_commits_when_changelog_is_stale() {
+    let repo = fixture_release_repo("feat: add billing export");
+    fs::write(repo.path().join("CHANGELOG.md"), STALE_CHANGELOG).unwrap();
+
+    let args = synthesize_args_with_repo(repo.path(), "v1.1.0");
+    let mut config = test_synthesis_config();
+    config.changelog_source = "auto".into();
+
+    let technical = resolve_technical_changelog(&args, &config).expect("grounded changelog");
+
+    assert!(
+        technical.contains("feat: add billing export"),
+        "auto source should be grounded in the release commit range:\n{technical}"
+    );
+    assert!(
+        !technical.contains("stale unrelated bugfix"),
+        "stale changelog section must not silently ground synthesis:\n{technical}"
+    );
+}
+
+#[test]
+fn resolve_technical_changelog_auto_rejects_pr_text_that_does_not_match_release_commits() {
+    let repo = fixture_release_repo("fix: recover canary check-ins");
+    fs::write(
+        repo.path().join("pr-changelog.md"),
+        "- ancient unrelated dashboard rewrite (#41) by @octocat\n",
+    )
+    .unwrap();
+
+    let args = synthesize_args_with_repo(repo.path(), "v1.1.0");
+    let mut config = test_synthesis_config();
+    config.changelog_source = "auto".into();
+
+    let technical = resolve_technical_changelog(&args, &config).expect("grounded changelog");
+
+    assert!(
+        technical.contains("fix: recover canary check-ins"),
+        "auto source should keep the release-scoped commit:\n{technical}"
+    );
+    assert!(
+        !technical.contains("ancient unrelated dashboard rewrite"),
+        "out-of-range PR text must not become synthesis ground truth:\n{technical}"
+    );
+}
+
+#[test]
+fn resolve_technical_changelog_explicit_source_keeps_mismatch_visible() {
+    let repo = fixture_release_repo("fix: ship the actual release");
+    fs::write(
+        repo.path().join("CHANGELOG.md"),
+        "## [1.1.0]\n\n- feat: stale unrelated dashboard rewrite\n",
+    )
+    .unwrap();
+
+    let args = synthesize_args_with_repo(repo.path(), "v1.1.0");
+    let mut config = test_synthesis_config();
+    config.changelog_source = "changelog".into();
+
+    let technical = resolve_technical_changelog(&args, &config).expect("explicit source retained");
+
+    assert!(technical.contains("fix: ship the actual release"));
+    assert!(technical.contains("feat: stale unrelated dashboard rewrite"));
+    assert!(
+        technical.contains("selected changelog source does not match release commits"),
+        "explicit mismatch should be visible, not silently trusted:\n{technical}"
+    );
+    assert!(
+        technical.contains("Selected technical source (changelog; does not match release commits)"),
+        "selected source status should be rendered for model and operator review:\n{technical}"
+    );
+}
+
+#[test]
 fn classification_notice_is_collapsed_out_of_the_visible_release_body() {
     let notes = "## Improvements\n\n- Added a safer classifier.\n";
     let classification = ReleaseClassification {
@@ -134,4 +207,26 @@ fn classification_notice_is_collapsed_out_of_the_visible_release_body() {
     assert!(rendered.contains("Landmark classification notice"));
     // The published body up top should read as plain release notes, not debug output.
     assert!(rendered.starts_with("## Improvements"));
+}
+
+fn fixture_release_repo(release_subject: &str) -> tempfile::TempDir {
+    let repo = tempfile::tempdir().unwrap();
+    run_ok("git", ["init", "-q"], repo.path()).unwrap();
+    run_ok("git", ["config", "user.name", "Landmark Test"], repo.path()).unwrap();
+    run_ok(
+        "git",
+        ["config", "user.email", "landmark@example.invalid"],
+        repo.path(),
+    )
+    .unwrap();
+    fs::write(repo.path().join("README.md"), "# Fixture\n").unwrap();
+    run_ok("git", ["add", "README.md"], repo.path()).unwrap();
+    run_ok("git", ["commit", "-q", "-m", "chore: seed"], repo.path()).unwrap();
+    run_ok("git", ["tag", "v1.0.0"], repo.path()).unwrap();
+
+    fs::write(repo.path().join("release.txt"), release_subject).unwrap();
+    run_ok("git", ["add", "release.txt"], repo.path()).unwrap();
+    run_ok("git", ["commit", "-q", "-m", release_subject], repo.path()).unwrap();
+    run_ok("git", ["tag", "v1.1.0"], repo.path()).unwrap();
+    repo
 }

--- a/templates/prompts/developer.md
+++ b/templates/prompts/developer.md
@@ -40,4 +40,6 @@ Do not add intro or summary text outside the sections.
 
 Technical changelog source:
 
+Grounding rule: treat the release commit list in the source below as authoritative. If supplemental changelog, release-body, or PR text conflicts with those commits or the diff stats, ignore the supplemental text.
+
 {{TECHNICAL_CHANGELOG}}

--- a/templates/prompts/end-user.md
+++ b/templates/prompts/end-user.md
@@ -41,4 +41,6 @@ Do not add intro or summary text outside the sections.
 
 Technical changelog source:
 
+Grounding rule: treat the release commit list in the source below as authoritative. If supplemental changelog, release-body, or PR text conflicts with those commits or the diff stats, ignore the supplemental text.
+
 {{TECHNICAL_CHANGELOG}}

--- a/templates/prompts/enterprise.md
+++ b/templates/prompts/enterprise.md
@@ -42,4 +42,6 @@ Do not add intro or summary text outside the sections.
 
 Technical changelog source:
 
+Grounding rule: treat the release commit list in the source below as authoritative. If supplemental changelog, release-body, or PR text conflicts with those commits or the diff stats, ignore the supplemental text.
+
 {{TECHNICAL_CHANGELOG}}

--- a/templates/prompts/general.md
+++ b/templates/prompts/general.md
@@ -39,4 +39,6 @@ Do not add any intro, outro, summary, or sign-off text. Start directly with the 
 
 Technical changelog source:
 
+Grounding rule: treat the release commit list in the source below as authoritative. If supplemental changelog, release-body, or PR text conflicts with those commits or the diff stats, ignore the supplemental text.
+
 {{TECHNICAL_CHANGELOG}}

--- a/templates/synthesis-prompt.md
+++ b/templates/synthesis-prompt.md
@@ -8,6 +8,8 @@ Transform the technical changelog below into user-facing release notes.
 
 {{BREAKING_CHANGES_SECTION}}
 
+Grounding rule: treat the release commit list in the source below as authoritative. If supplemental changelog, release-body, or PR text conflicts with those commits or the diff stats, ignore the supplemental text.
+
 ## Writing guidelines
 
 - **Breaking changes:** If breaking changes are provided above, write them first under `## Breaking Changes`. 2-3 sentences each: what changed, why, migration steps. Do not repeat them in other sections.


### PR DESCRIPTION
## Summary
- add a shared release grounding bundle for synthesis and classification
- make auto changelog resolution fall back to release-scoped git commits when changelog/release-body/PR text does not match the release commits
- record grounding metadata and add prompt grounding rules across synthesis templates

## Regression coverage
- stale changelog section no longer silently grounds synthesis
- mismatched PR text no longer becomes auto ground truth
- explicit mismatched changelog override remains visible with warnings
- replay scenario `release_grounding_unified_path` exercises the real synthesize subprocess

## Verification
- `cargo test --locked -p landmark synthesis_tests -- --nocapture`
- `bin/replay-action --scenario release_grounding_unified_path --evidence-dir .landmark/replay-grounding --format json`
- `bin/replay-action --evidence-dir .landmark/replay --format json`
- `bin/gate`

## Review
Fresh-context pi critic: `BLOCKING: No`. Its explicit-override mismatch proof gap was addressed with `resolve_technical_changelog_explicit_source_keeps_mismatch_visible` and a resolver comment.

Agent: Codex
Agent-Surface: Codex CLI
Agent-Model: GPT-5
Agent-Task: backlog.d/011-unify-classification-and-synthesis-grounding.md

Do not merge from this lane; requested deliverable is PR only.