### PR TITLE
Ground semver decisions in API evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,8 +380,14 @@ Use `landmark run --provider local --repo-root .` to write a release-kit
 plan at `.landmark/run/release-kit.json` and record its schema and hash in
 `.landmark/run/evidence.json`; the evidence packet includes the deterministic
 version decision and changed-file list so downstream producers do not have to
-re-read git state. `--dry-run` keeps the filesystem untouched and prints the
-same `release_kit` object inside the stdout evidence packet. Low internal
+re-read git state. For Rust crate repositories, the version decision also runs
+`cargo semver-checks --baseline-rev <previous-tag>` against the current checkout
+and records the public API evidence as `version_decision.api_evidence`.
+Conventional commits remain the deterministic floor: semver evidence can
+upgrade the bump, a provider skip or failure is recorded without silently
+changing the floor, and a commit/API disagreement records a typed waiver need
+instead of hiding the conflict. `--dry-run` keeps the filesystem untouched and
+prints the same `release_kit` object inside the stdout evidence packet. Low internal
 releases keep the kit to Landmark-owned changelog and notes evidence;
 high-importance, security, breaking, or migration-heavy releases add planned
 producer-adapter artifacts such as migration guides, docs updates, blog drafts,
@@ -782,6 +788,13 @@ The command writes `.landmark/replay/replay-result.json` with action outputs,
 generated notes, release body before/after state, git tags, structured logs, and
 fake service requests. CI runs a bounded replay on pull requests, the full replay
 on `master`, and uploads the evidence packet for inspection.
+
+The diff-grounded version-decision scenarios are:
+`semver_evidence_agrees`, `semver_evidence_upgrades`,
+`semver_evidence_absent`, and `semver_evidence_tool_failure`. They use
+disposable fixture repos and a fake `cargo semver-checks` binary so the replay
+proves Landmark's reconciliation and evidence schema without depending on a
+developer machine's installed cargo subcommands.
 
 For a local one-command gate, run:
 

--- a/crates/landmark/src/main.rs
+++ b/crates/landmark/src/main.rs
@@ -41,6 +41,7 @@ mod release_kit_tests;
 mod release_ops;
 mod replay;
 mod self_release;
+mod semver_evidence;
 mod setup_fleet;
 mod synthesis;
 #[cfg(test)]
@@ -51,6 +52,7 @@ mod util;
 mod version_decision;
 #[cfg(test)]
 mod version_decision_tests;
+mod version_reconciliation;
 
 pub(crate) use cli::*;
 pub(crate) use describe::*;
@@ -64,10 +66,12 @@ pub(crate) use release_grounding::*;
 pub(crate) use release_ops::*;
 pub(crate) use replay::*;
 pub(crate) use self_release::*;
+pub(crate) use semver_evidence::*;
 pub(crate) use setup_fleet::*;
 pub(crate) use synthesis::*;
 pub(crate) use util::*;
 pub(crate) use version_decision::*;
+pub(crate) use version_reconciliation::*;
 
 pub(crate) type Result<T> = std::result::Result<T, Box<dyn Error>>;
 

--- a/crates/landmark/src/release_feed_tests.rs
+++ b/crates/landmark/src/release_feed_tests.rs
@@ -27,11 +27,36 @@ fn notify_release_feed_posts_signed_release_kit_with_text_floor_artifacts() {
             "version_decision": {
                 "latest_tag": "v1.2.2",
                 "bump": "minor",
+                "commit_bump": "minor",
+                "api_evidence_bump": "none",
+                "reconciliation": "unavailable",
                 "commit_count": 1,
                 "conventional_commit_count": 1,
                 "range": "v1.2.2..HEAD",
                 "decisive_commit": "feat(feed): publish release evidence (abc1234)",
-                "unknown_commits": []
+                "decisive_signals": [
+                    "commit:abc1234 feat(feed): publish release evidence",
+                    "api-evidence:none skipped no evidence provider: no Cargo.toml at repository root"
+                ],
+                "unknown_commits": [],
+                "api_evidence": {
+                    "provider": "none",
+                    "status": "skipped",
+                    "bump": "none",
+                    "baseline": "",
+                    "target": "",
+                    "command": "",
+                    "exit_code": 0,
+                    "summary": "no evidence provider: no Cargo.toml at repository root",
+                    "findings": [],
+                    "failure_message": ""
+                },
+                "waiver": {
+                    "required": false,
+                    "status": "not-required",
+                    "kind": "",
+                    "reason": ""
+                }
             }
         },
         "classification": {"importance": "medium", "audiences": ["developer"], "why_it_matters": "release feed evidence"},

--- a/crates/landmark/src/release_kit_tests.rs
+++ b/crates/landmark/src/release_kit_tests.rs
@@ -23,11 +23,22 @@ fn baseline_decision() -> RunVersionDecision {
     RunVersionDecision {
         latest_tag: "v1.0.0".into(),
         bump: "minor".into(),
+        commit_bump: "minor".into(),
+        api_evidence_bump: "none".into(),
+        reconciliation: "unavailable".into(),
         commit_count: 1,
         conventional_commit_count: 1,
         range: "v1.0.0..HEAD".into(),
         decisive_commit: None,
+        decisive_signals: Vec::new(),
         unknown_commits: Vec::new(),
+        api_evidence: no_version_api_evidence("test fixture"),
+        waiver: VersionDecisionWaiver {
+            required: false,
+            status: "not-required".into(),
+            kind: String::new(),
+            reason: String::new(),
+        },
     }
 }
 

--- a/crates/landmark/src/release_ops/feed_adapter.rs
+++ b/crates/landmark/src/release_ops/feed_adapter.rs
@@ -93,6 +93,7 @@ fn enrich_release_feed_kit(
     let version_decision = evidence
         .get("version_decision")
         .ok_or("evidence missing version_decision")?;
+    validate_release_feed_version_decision(version_decision)?;
     let changed_files = evidence
         .get("changed_files")
         .and_then(Value::as_array)
@@ -132,7 +133,7 @@ fn enrich_release_feed_kit(
             "sha256": sha256_json(version_decision)?,
             "acceptance": [
                 "Carries the exact deterministic version decision from run-evidence.v1.",
-                "Names the bump, release range, decisive commit, and unknown commits."
+                "Names the bump, release range, decisive signals, API evidence, and waiver state."
             ]
         }),
     )?;
@@ -217,6 +218,46 @@ fn enrich_release_feed_kit(
 
 fn sha256_json(value: &Value) -> Result<String> {
     Ok(sha256_hex(&serde_json::to_vec(value)?))
+}
+
+fn validate_release_feed_version_decision(version_decision: &Value) -> Result<()> {
+    for pointer in [
+        "/latest_tag",
+        "/bump",
+        "/commit_bump",
+        "/api_evidence_bump",
+        "/reconciliation",
+        "/range",
+        "/api_evidence/provider",
+        "/api_evidence/status",
+        "/api_evidence/summary",
+        "/waiver/status",
+    ] {
+        if version_decision
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .is_none()
+        {
+            return Err(format!("version_decision missing string at {pointer}").into());
+        }
+    }
+    for pointer in ["/decisive_signals", "/unknown_commits"] {
+        if version_decision
+            .pointer(pointer)
+            .and_then(Value::as_array)
+            .is_none()
+        {
+            return Err(format!("version_decision missing array at {pointer}").into());
+        }
+    }
+    if version_decision
+        .pointer("/waiver/required")
+        .and_then(Value::as_bool)
+        .is_none()
+    {
+        return Err("version_decision missing boolean at /waiver/required".into());
+    }
+    Ok(())
 }
 
 fn upsert_artifact(release_kit: &mut Value, artifact: Value) -> Result<()> {

--- a/crates/landmark/src/release_ops/models.rs
+++ b/crates/landmark/src/release_ops/models.rs
@@ -206,11 +206,17 @@ pub(crate) struct RunEvidence {
 pub(crate) struct RunVersionDecision {
     pub(crate) latest_tag: String,
     pub(crate) bump: String,
+    pub(crate) commit_bump: String,
+    pub(crate) api_evidence_bump: String,
+    pub(crate) reconciliation: String,
     pub(crate) commit_count: usize,
     pub(crate) conventional_commit_count: usize,
     pub(crate) range: String,
     pub(crate) decisive_commit: Option<String>,
+    pub(crate) decisive_signals: Vec<String>,
     pub(crate) unknown_commits: Vec<String>,
+    pub(crate) api_evidence: VersionApiEvidence,
+    pub(crate) waiver: VersionDecisionWaiver,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/crates/landmark/src/release_ops/run.rs
+++ b/crates/landmark/src/release_ops/run.rs
@@ -113,13 +113,18 @@ pub(crate) fn resolve_local_release(args: &RunArgs) -> Result<RunReleaseContext>
         .iter()
         .map(|commit| classify_commit(&commit.short_hash, &commit.subject, &commit.body))
         .collect();
-    let decision = decide_version(&classified);
+    let api_evidence = CargoSemverChecksProvider.collect(&VersionApiEvidenceRequest {
+        repo_root: &args.repo_root,
+        previous_tag: &previous_tag,
+        target_ref: &target_ref,
+    });
+    let decision = decide_version_with_api_evidence(&classified, api_evidence);
     let bump = decision.bump.map(VersionBump::as_str).unwrap_or("none");
     let release_tag =
         explicit_release_tag.unwrap_or_else(|| next_release_tag(latest_tag.as_ref(), bump));
     let version = release_tag.trim_start_matches('v').to_string();
     let range = if previous_tag.is_empty() {
-        target_ref
+        target_ref.clone()
     } else {
         format!("{previous_tag}..{target_ref}")
     };
@@ -131,15 +136,21 @@ pub(crate) fn resolve_local_release(args: &RunArgs) -> Result<RunReleaseContext>
         decision: RunVersionDecision {
             latest_tag: latest_tag.map(|tag| tag.tag).unwrap_or_default(),
             bump: bump.to_string(),
+            commit_bump: decision.commit_bump,
+            api_evidence_bump: decision.api_evidence_bump,
+            reconciliation: decision.reconciliation,
             commit_count: commits.len(),
             conventional_commit_count,
             range,
             decisive_commit: decision.decisive.map(|commit| commit.evidence_line()),
+            decisive_signals: decision.decisive_signals,
             unknown_commits: decision
                 .unknown_commits
                 .iter()
                 .map(ClassifiedCommit::evidence_line)
                 .collect(),
+            api_evidence: decision.api_evidence,
+            waiver: decision.waiver,
         },
         commits,
     })

--- a/crates/landmark/src/replay/mod.rs
+++ b/crates/landmark/src/replay/mod.rs
@@ -146,6 +146,22 @@ pub(crate) fn scenario_map() -> BTreeMap<String, Scenario> {
         scenario_release_grounding_unified_path,
     );
     map.insert(
+        "semver_evidence_agrees".to_string(),
+        scenario_semver_evidence_agrees,
+    );
+    map.insert(
+        "semver_evidence_upgrades".to_string(),
+        scenario_semver_evidence_upgrades,
+    );
+    map.insert(
+        "semver_evidence_absent".to_string(),
+        scenario_semver_evidence_absent,
+    );
+    map.insert(
+        "semver_evidence_tool_failure".to_string(),
+        scenario_semver_evidence_tool_failure,
+    );
+    map.insert(
         "first_run_local_preview".to_string(),
         scenario_first_run_local_preview,
     );
@@ -241,6 +257,10 @@ pub(crate) fn canonical_scenarios() -> Vec<&'static str> {
         "local_provider_run",
         "release_kit_classification_uses_structured_commits",
         "release_grounding_unified_path",
+        "semver_evidence_agrees",
+        "semver_evidence_upgrades",
+        "semver_evidence_absent",
+        "semver_evidence_tool_failure",
         "provider_run_parity",
         "manifest_defaults_and_overrides",
         "consumer_release_update_failure",

--- a/crates/landmark/src/replay/provider_scenarios/mod.rs
+++ b/crates/landmark/src/replay/provider_scenarios/mod.rs
@@ -7,6 +7,7 @@ mod pr_scoping;
 mod provider_runs;
 mod release_body_idempotency;
 mod self_release;
+mod semver_evidence;
 mod synthesis_cost;
 
 pub(crate) use consumers::*;
@@ -17,6 +18,7 @@ pub(crate) use pr_scoping::*;
 pub(crate) use provider_runs::*;
 pub(crate) use release_body_idempotency::*;
 pub(crate) use self_release::*;
+pub(crate) use semver_evidence::*;
 pub(crate) use synthesis_cost::*;
 
 #[derive(Default)]

--- a/crates/landmark/src/replay/provider_scenarios/semver_evidence.rs
+++ b/crates/landmark/src/replay/provider_scenarios/semver_evidence.rs
@@ -1,0 +1,265 @@
+use crate::*;
+
+pub(crate) fn scenario_semver_evidence_agrees(tmp_root: &Path) -> Result<Value> {
+    let repo = tmp_root.join("semver-evidence-agrees");
+    init_rust_fixture_repo(&repo, "v1.0.0")?;
+    fs::write(repo.join("src/lib.rs"), "pub fn renamed_api() {}\n")?;
+    run_ok("git", ["add", "src/lib.rs"], &repo)?;
+    run_ok(
+        "git",
+        ["commit", "-q", "-m", "feat(api)!: rename stable API"],
+        &repo,
+    )?;
+    run_ok("git", ["tag", "v2.0.0"], &repo)?;
+
+    let evidence = run_with_fake_cargo_semver(tmp_root, &repo, "findings", Some("v2.0.0"))?;
+    assert_decision(&evidence, "major", "major", "major", "agreed", "findings")?;
+    assert_json_eq(
+        &evidence,
+        "/version_decision/api_evidence/target",
+        "v2.0.0",
+        "explicit release tag evidence target",
+    )?;
+    assert_release_kit_carries_decision(&evidence)?;
+    Ok(json!({
+        "decision": evidence["version_decision"],
+        "release_kit_decision": evidence["release_kit"]["release"]["version_decision"],
+    }))
+}
+
+pub(crate) fn scenario_semver_evidence_upgrades(tmp_root: &Path) -> Result<Value> {
+    let repo = tmp_root.join("semver-evidence-upgrades");
+    init_rust_fixture_repo(&repo, "v1.0.0")?;
+    fs::write(repo.join("src/lib.rs"), "pub fn renamed_api() {}\n")?;
+    run_ok("git", ["add", "src/lib.rs"], &repo)?;
+    run_ok(
+        "git",
+        ["commit", "-q", "-m", "feat(api): add replacement API"],
+        &repo,
+    )?;
+
+    let evidence = run_with_fake_cargo_semver(tmp_root, &repo, "findings", None)?;
+    assert_decision(&evidence, "major", "minor", "major", "upgraded", "findings")?;
+    assert_json_eq(
+        &evidence,
+        "/release_tag",
+        "v2.0.0",
+        "semver evidence upgrade tag",
+    )?;
+    assert_release_kit_carries_decision(&evidence)?;
+    Ok(json!({
+        "decision": evidence["version_decision"],
+        "release_tag": evidence["release_tag"],
+    }))
+}
+
+pub(crate) fn scenario_semver_evidence_absent(tmp_root: &Path) -> Result<Value> {
+    let repo = tmp_root.join("semver-evidence-absent");
+    init_fixture_repo(&repo, "v1.0.0")?;
+    fs::write(repo.join("fix.txt"), "patch\n")?;
+    run_ok("git", ["add", "fix.txt"], &repo)?;
+    run_ok(
+        "git",
+        ["commit", "-q", "-m", "fix(cli): patch output"],
+        &repo,
+    )?;
+
+    let evidence = run_landmark_run(&repo, None, None)?;
+    assert_decision(
+        &evidence,
+        "patch",
+        "patch",
+        "none",
+        "unavailable",
+        "skipped",
+    )?;
+    assert_json_eq(
+        &evidence,
+        "/version_decision/api_evidence/provider",
+        "none",
+        "absent evidence provider",
+    )?;
+    let summary = evidence["version_decision"]["api_evidence"]["summary"]
+        .as_str()
+        .unwrap_or_default();
+    if !summary.contains("no evidence provider") {
+        return Err("absent evidence scenario did not record no-provider note".into());
+    }
+    assert_release_kit_carries_decision(&evidence)?;
+    Ok(json!({
+        "decision": evidence["version_decision"],
+        "release_tag": evidence["release_tag"],
+    }))
+}
+
+pub(crate) fn scenario_semver_evidence_tool_failure(tmp_root: &Path) -> Result<Value> {
+    let repo = tmp_root.join("semver-evidence-tool-failure");
+    init_rust_fixture_repo(&repo, "v1.0.0")?;
+    fs::write(
+        repo.join("src/lib.rs"),
+        "pub fn stable_api() {}\npub fn patched() {}\n",
+    )?;
+    run_ok("git", ["add", "src/lib.rs"], &repo)?;
+    run_ok(
+        "git",
+        ["commit", "-q", "-m", "fix(api): patch helper"],
+        &repo,
+    )?;
+
+    let evidence = run_with_fake_cargo_semver(tmp_root, &repo, "failed", None)?;
+    assert_decision(&evidence, "patch", "patch", "none", "unverified", "failed")?;
+    let failure = evidence["version_decision"]["api_evidence"]["failure_message"]
+        .as_str()
+        .unwrap_or_default();
+    if !failure.contains("rustdoc JSON unavailable") {
+        return Err("tool failure scenario did not preserve failure message".into());
+    }
+    assert_release_kit_carries_decision(&evidence)?;
+    Ok(json!({
+        "decision": evidence["version_decision"],
+        "release_tag": evidence["release_tag"],
+    }))
+}
+
+fn run_with_fake_cargo_semver(
+    tmp_root: &Path,
+    repo: &Path,
+    mode: &str,
+    release_tag: Option<&str>,
+) -> Result<Value> {
+    let fake_bin = tmp_root.join("fake-cargo-bin");
+    fs::create_dir_all(&fake_bin)?;
+    let fake_cargo = fake_bin.join("cargo");
+    fs::write(
+        &fake_cargo,
+        "#!/bin/sh\nif [ \"$1\" = \"semver-checks\" ]; then\n  case \"$LANDMARK_FAKE_SEMVER\" in\n    passed)\n      echo \"SemVer check passed\"\n      exit 0\n      ;;\n    findings)\n      echo \"SemVer check failed\"\n      echo \"Breaking changes detected\"\n      echo \"Required bump: Major\"\n      exit 1\n      ;;\n    failed)\n      echo \"error: rustdoc JSON unavailable\" >&2\n      exit 2\n      ;;\n  esac\nfi\necho \"fake cargo only supports semver-checks\" >&2\nexit 64\n",
+    )?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&fake_cargo, fs::Permissions::from_mode(0o755))?;
+    }
+    run_landmark_run(repo, Some((&fake_bin, mode)), release_tag)
+}
+
+fn run_landmark_run(
+    repo: &Path,
+    fake_cargo: Option<(&Path, &str)>,
+    release_tag: Option<&str>,
+) -> Result<Value> {
+    let mut command = Command::new(current_exe());
+    command.args([
+        "run",
+        "--provider",
+        "local",
+        "--repo-root",
+        repo.to_str().unwrap(),
+        "--repository",
+        "semver-evidence",
+        "--output-dir",
+        ".landmark/run",
+        "--technical-changelog-file",
+        ".landmark/run/technical.md",
+        "--evidence-file",
+        ".landmark/run/evidence.json",
+        "--output-file",
+        "",
+        "--output-text-file",
+        "",
+        "--output-html-file",
+        "",
+        "--output-json",
+        "",
+        "--rss-feed-file",
+        "",
+    ]);
+    if let Some(release_tag) = release_tag {
+        command.args(["--release-tag", release_tag]);
+    }
+    if let Some((fake_bin, mode)) = fake_cargo {
+        let path = format!(
+            "{}:{}",
+            fake_bin.display(),
+            env::var("PATH").unwrap_or_default()
+        );
+        command.env("PATH", path);
+        command.env("LANDMARK_FAKE_SEMVER", mode);
+    }
+    let result = command.output()?;
+    if !result.status.success() {
+        return Err(String::from_utf8_lossy(&result.stderr).to_string().into());
+    }
+    let evidence_path = repo.join(".landmark/run/evidence.json");
+    let file_evidence: Value = serde_json::from_str(&fs::read_to_string(&evidence_path)?)?;
+    let stdout_evidence: Value = serde_json::from_slice(&result.stdout)?;
+    if file_evidence != stdout_evidence {
+        return Err("semver evidence stdout did not match written evidence".into());
+    }
+    Ok(file_evidence)
+}
+
+fn assert_decision(
+    evidence: &Value,
+    bump: &str,
+    commit_bump: &str,
+    api_bump: &str,
+    reconciliation: &str,
+    api_status: &str,
+) -> Result<()> {
+    assert_json_eq(evidence, "/version_decision/bump", bump, "decision bump")?;
+    assert_json_eq(
+        evidence,
+        "/version_decision/commit_bump",
+        commit_bump,
+        "commit bump",
+    )?;
+    assert_json_eq(
+        evidence,
+        "/version_decision/api_evidence_bump",
+        api_bump,
+        "api evidence bump",
+    )?;
+    assert_json_eq(
+        evidence,
+        "/version_decision/reconciliation",
+        reconciliation,
+        "reconciliation",
+    )?;
+    assert_json_eq(
+        evidence,
+        "/version_decision/api_evidence/status",
+        api_status,
+        "api evidence status",
+    )?;
+    let signals = evidence["version_decision"]["decisive_signals"]
+        .as_array()
+        .ok_or("decision missing decisive_signals")?;
+    if !signals.iter().any(|signal| {
+        signal
+            .as_str()
+            .unwrap_or_default()
+            .contains("api-evidence:")
+    }) {
+        return Err("decision did not name API evidence as a signal".into());
+    }
+    Ok(())
+}
+
+fn assert_release_kit_carries_decision(evidence: &Value) -> Result<()> {
+    release_kit_contract::assert_contract(&evidence["release_kit"], "semver evidence release kit")?;
+    if evidence["release_kit"]["release"]["version_decision"] != evidence["version_decision"] {
+        return Err("release kit did not carry exact run version decision".into());
+    }
+    Ok(())
+}
+
+fn assert_json_eq(value: &Value, pointer: &str, expected: &str, label: &str) -> Result<()> {
+    let actual = value
+        .pointer(pointer)
+        .and_then(Value::as_str)
+        .ok_or_else(|| format!("{label} missing JSON string at {pointer}"))?;
+    if actual != expected {
+        return Err(format!("{label} expected `{expected}`, got `{actual}`").into());
+    }
+    Ok(())
+}

--- a/crates/landmark/src/replay/release_feed_scenarios.rs
+++ b/crates/landmark/src/replay/release_feed_scenarios.rs
@@ -15,11 +15,36 @@ pub(crate) fn scenario_release_feed_adapter(tmp_root: &Path) -> Result<Value> {
     let version_decision = json!({
         "latest_tag": "v1.2.2",
         "bump": "minor",
+        "commit_bump": "minor",
+        "api_evidence_bump": "none",
+        "reconciliation": "unavailable",
         "commit_count": 1,
         "conventional_commit_count": 1,
         "range": "v1.2.2..HEAD",
         "decisive_commit": "feat(feed): publish release evidence (abc1234)",
-        "unknown_commits": []
+        "decisive_signals": [
+            "commit:abc1234 feat(feed): publish release evidence",
+            "api-evidence:none skipped no evidence provider: no Cargo.toml at repository root"
+        ],
+        "unknown_commits": [],
+        "api_evidence": {
+            "provider": "none",
+            "status": "skipped",
+            "bump": "none",
+            "baseline": "",
+            "target": "",
+            "command": "",
+            "exit_code": 0,
+            "summary": "no evidence provider: no Cargo.toml at repository root",
+            "findings": [],
+            "failure_message": ""
+        },
+        "waiver": {
+            "required": false,
+            "status": "not-required",
+            "kind": "",
+            "reason": ""
+        }
     });
     let release_kit = json!({
         "schema_version": "landmark.release-kit.v1",

--- a/crates/landmark/src/replay/support.rs
+++ b/crates/landmark/src/replay/support.rs
@@ -24,6 +24,35 @@ pub(crate) fn init_fixture_repo(path: &Path, release_tag: &str) -> Result<()> {
     Ok(())
 }
 
+pub(crate) fn init_rust_fixture_repo(path: &Path, release_tag: &str) -> Result<()> {
+    fs::create_dir_all(path.join("src"))?;
+    run_ok("git", ["init", "-q"], path)?;
+    run_ok("git", ["config", "user.name", "Landmark Replay"], path)?;
+    run_ok(
+        "git",
+        ["config", "user.email", "replay@example.invalid"],
+        path,
+    )?;
+    fs::write(path.join("README.md"), "# Rust Fixture\n")?;
+    fs::write(
+        path.join("Cargo.toml"),
+        "[package]\nname = \"landmark-replay-fixture\"\nversion = \"1.0.0\"\nedition = \"2021\"\n\n[lib]\npath = \"src/lib.rs\"\n",
+    )?;
+    fs::write(path.join("src/lib.rs"), "pub fn stable_api() {}\n")?;
+    fs::write(
+        path.join("CHANGELOG.md"),
+        format!("## {release_tag}\n\n- feat: replay Rust fixture\n"),
+    )?;
+    run_ok("git", ["add", "."], path)?;
+    run_ok(
+        "git",
+        ["commit", "-q", "-m", "feat: seed Rust replay fixture"],
+        path,
+    )?;
+    run_ok("git", ["tag", release_tag], path)?;
+    Ok(())
+}
+
 pub(crate) fn git_tags(path: &Path) -> Result<Vec<String>> {
     Ok(run_ok("git", ["tag", "--list", "--sort=refname"], path)?
         .lines()

--- a/crates/landmark/src/semver_evidence.rs
+++ b/crates/landmark/src/semver_evidence.rs
@@ -1,0 +1,195 @@
+use crate::*;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct VersionApiEvidence {
+    pub(crate) provider: String,
+    pub(crate) status: String,
+    pub(crate) bump: String,
+    pub(crate) baseline: String,
+    pub(crate) target: String,
+    pub(crate) command: String,
+    pub(crate) exit_code: i32,
+    pub(crate) summary: String,
+    pub(crate) findings: Vec<String>,
+    pub(crate) failure_message: String,
+}
+
+pub(crate) struct VersionApiEvidenceRequest<'a> {
+    pub(crate) repo_root: &'a Path,
+    pub(crate) previous_tag: &'a str,
+    pub(crate) target_ref: &'a str,
+}
+
+pub(crate) trait VersionApiEvidenceProvider {
+    fn collect(&self, request: &VersionApiEvidenceRequest<'_>) -> VersionApiEvidence;
+}
+
+pub(crate) struct CargoSemverChecksProvider;
+
+pub(crate) fn no_version_api_evidence(reason: &str) -> VersionApiEvidence {
+    VersionApiEvidence {
+        provider: "none".into(),
+        status: "skipped".into(),
+        bump: "none".into(),
+        baseline: String::new(),
+        target: String::new(),
+        command: String::new(),
+        exit_code: 0,
+        summary: format!("no evidence provider: {reason}"),
+        findings: Vec::new(),
+        failure_message: String::new(),
+    }
+}
+
+impl VersionApiEvidenceProvider for CargoSemverChecksProvider {
+    fn collect(&self, request: &VersionApiEvidenceRequest<'_>) -> VersionApiEvidence {
+        if !request.repo_root.join("Cargo.toml").is_file() {
+            return no_version_api_evidence("no Cargo.toml at repository root");
+        }
+        if request.previous_tag.trim().is_empty() {
+            return skipped_cargo_semver_evidence(
+                request,
+                "no previous release tag; cargo-semver-checks needs a baseline",
+            );
+        }
+        if !target_matches_current_checkout(request.repo_root, request.target_ref) {
+            return skipped_cargo_semver_evidence(
+                request,
+                "target ref does not resolve to the current checkout; cargo-semver-checks evidence would not match the selected release range",
+            );
+        }
+
+        let command = cargo_semver_command(request.previous_tag);
+        let output = match run_cmd(
+            "cargo",
+            ["semver-checks", "--baseline-rev", request.previous_tag],
+            request.repo_root,
+        ) {
+            Ok(output) => output,
+            Err(error) => {
+                return VersionApiEvidence {
+                    provider: "cargo-semver-checks".into(),
+                    status: "failed".into(),
+                    bump: "none".into(),
+                    baseline: request.previous_tag.into(),
+                    target: request.target_ref.into(),
+                    command,
+                    exit_code: -1,
+                    summary: "cargo-semver-checks could not be started".into(),
+                    findings: Vec::new(),
+                    failure_message: sanitize_text(&error.to_string()),
+                };
+            }
+        };
+
+        let exit_code = output.status.code().unwrap_or(-1);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let combined = format!("{stdout}\n{stderr}");
+        if output.status.success() {
+            return VersionApiEvidence {
+                provider: "cargo-semver-checks".into(),
+                status: "passed".into(),
+                bump: "none".into(),
+                baseline: request.previous_tag.into(),
+                target: request.target_ref.into(),
+                command,
+                exit_code,
+                summary: "cargo-semver-checks passed; no public API breaking evidence found".into(),
+                findings: output_excerpt(&combined),
+                failure_message: String::new(),
+            };
+        }
+
+        if looks_like_semver_violation(&combined) {
+            VersionApiEvidence {
+                provider: "cargo-semver-checks".into(),
+                status: "findings".into(),
+                bump: "major".into(),
+                baseline: request.previous_tag.into(),
+                target: request.target_ref.into(),
+                command,
+                exit_code,
+                summary: "cargo-semver-checks reported public API SemVer violations; major bump evidence recorded".into(),
+                findings: output_excerpt(&combined),
+                failure_message: String::new(),
+            }
+        } else {
+            VersionApiEvidence {
+                provider: "cargo-semver-checks".into(),
+                status: "failed".into(),
+                bump: "none".into(),
+                baseline: request.previous_tag.into(),
+                target: request.target_ref.into(),
+                command,
+                exit_code,
+                summary: "cargo-semver-checks failed before producing trusted SemVer findings"
+                    .into(),
+                findings: Vec::new(),
+                failure_message: output_excerpt(&combined).join(" | "),
+            }
+        }
+    }
+}
+
+fn skipped_cargo_semver_evidence(
+    request: &VersionApiEvidenceRequest<'_>,
+    reason: &str,
+) -> VersionApiEvidence {
+    VersionApiEvidence {
+        provider: "cargo-semver-checks".into(),
+        status: "skipped".into(),
+        bump: "none".into(),
+        baseline: request.previous_tag.into(),
+        target: request.target_ref.into(),
+        command: cargo_semver_command(request.previous_tag),
+        exit_code: 0,
+        summary: reason.into(),
+        findings: Vec::new(),
+        failure_message: String::new(),
+    }
+}
+
+fn cargo_semver_command(previous_tag: &str) -> String {
+    format!("cargo semver-checks --baseline-rev {previous_tag}")
+}
+
+fn target_matches_current_checkout(repo_root: &Path, target_ref: &str) -> bool {
+    if target_ref == "HEAD" {
+        return true;
+    }
+    let Ok(target) = git_commit(repo_root, target_ref) else {
+        return false;
+    };
+    let Ok(head) = git_commit(repo_root, "HEAD") else {
+        return false;
+    };
+    target == head
+}
+
+fn git_commit(repo_root: &Path, rev: &str) -> Result<String> {
+    Ok(run_ok(
+        "git",
+        ["rev-parse", &format!("{rev}^{{commit}}")],
+        repo_root,
+    )?
+    .trim()
+    .to_string())
+}
+
+fn looks_like_semver_violation(output: &str) -> bool {
+    let lower = output.to_ascii_lowercase();
+    lower.contains("breaking changes detected")
+        || lower.contains("semver violation")
+        || lower.contains("semver check failed")
+        || lower.contains("required bump")
+}
+
+fn output_excerpt(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .map(sanitize_text)
+        .filter(|line| !line.trim().is_empty())
+        .take(12)
+        .collect()
+}

--- a/crates/landmark/src/version_decision.rs
+++ b/crates/landmark/src/version_decision.rs
@@ -15,6 +15,15 @@ impl VersionBump {
             VersionBump::Major => "major",
         }
     }
+
+    pub(crate) fn from_str(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "patch" => Some(VersionBump::Patch),
+            "minor" => Some(VersionBump::Minor),
+            "major" => Some(VersionBump::Major),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)]

--- a/crates/landmark/src/version_decision_tests.rs
+++ b/crates/landmark/src/version_decision_tests.rs
@@ -206,3 +206,72 @@ fn rename_commit_alongside_real_signal_never_blocks_the_release() {
     assert_eq!(decision.unknown_commits.len(), 1);
     assert_eq!(decision.unknown_commits[0].id, "a");
 }
+
+fn api_evidence(status: &str, bump: &str) -> VersionApiEvidence {
+    VersionApiEvidence {
+        provider: "cargo-semver-checks".into(),
+        status: status.into(),
+        bump: bump.into(),
+        baseline: "v1.0.0".into(),
+        target: "HEAD".into(),
+        command: "cargo semver-checks --baseline-rev v1.0.0".into(),
+        exit_code: 0,
+        summary: format!("fixture {status}"),
+        findings: Vec::new(),
+        failure_message: String::new(),
+    }
+}
+
+#[test]
+fn api_evidence_can_upgrade_commit_floor_but_never_downgrade_it() {
+    let commits = [commit("a", "feat(api): add helper", "")];
+    let reconciled = decide_version_with_api_evidence(&commits, api_evidence("findings", "major"));
+    assert_eq!(reconciled.bump, Some(VersionBump::Major));
+    assert_eq!(reconciled.commit_bump, "minor");
+    assert_eq!(reconciled.api_evidence_bump, "major");
+    assert_eq!(reconciled.reconciliation, "upgraded");
+    assert!(
+        reconciled
+            .decisive_signals
+            .iter()
+            .any(|signal| signal.contains("api-evidence:cargo-semver-checks"))
+    );
+
+    let floor = decide_version_with_api_evidence(
+        &[commit("b", "feat(api)!: rename helper", "")],
+        api_evidence("passed", "none"),
+    );
+    assert_eq!(floor.bump, Some(VersionBump::Major));
+    assert_eq!(floor.reconciliation, "conflict");
+    assert_eq!(floor.waiver.status, "missing");
+    assert!(floor.waiver.required);
+}
+
+#[test]
+fn absent_or_failed_api_evidence_keeps_the_floor_loudly() {
+    let commits = [commit("a", "fix(cli): patch output", "")];
+    let absent =
+        decide_version_with_api_evidence(&commits, no_version_api_evidence("no Cargo.toml"));
+    assert_eq!(absent.bump, Some(VersionBump::Patch));
+    assert_eq!(absent.reconciliation, "unavailable");
+    assert_eq!(absent.api_evidence.status, "skipped");
+    assert!(
+        absent
+            .decisive_signals
+            .iter()
+            .any(|signal| signal.contains("api-evidence:none skipped"))
+    );
+
+    let mut failed = api_evidence("failed", "none");
+    failed.failure_message = "cargo semver-checks exited 2".into();
+    let failed = decide_version_with_api_evidence(&commits, failed);
+    assert_eq!(failed.bump, Some(VersionBump::Patch));
+    assert_eq!(failed.reconciliation, "unverified");
+    assert_eq!(failed.waiver.status, "not-required");
+    assert!(
+        failed
+            .decisive_signals
+            .iter()
+            .any(|signal| signal.contains("api-evidence:cargo-semver-checks failed"))
+    );
+}

--- a/crates/landmark/src/version_reconciliation.rs
+++ b/crates/landmark/src/version_reconciliation.rs
@@ -1,0 +1,103 @@
+use crate::*;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct VersionDecisionWaiver {
+    pub(crate) required: bool,
+    pub(crate) status: String,
+    pub(crate) kind: String,
+    pub(crate) reason: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct ReconciledVersionDecision {
+    pub(crate) bump: Option<VersionBump>,
+    pub(crate) decisive: Option<ClassifiedCommit>,
+    pub(crate) unknown_commits: Vec<ClassifiedCommit>,
+    pub(crate) commit_bump: String,
+    pub(crate) api_evidence_bump: String,
+    pub(crate) reconciliation: String,
+    pub(crate) decisive_signals: Vec<String>,
+    pub(crate) api_evidence: VersionApiEvidence,
+    pub(crate) waiver: VersionDecisionWaiver,
+}
+
+pub(crate) fn decide_version_with_api_evidence(
+    commits: &[ClassifiedCommit],
+    api_evidence: VersionApiEvidence,
+) -> ReconciledVersionDecision {
+    let commit_decision = decide_version(commits);
+    let commit_bump = bump_label(commit_decision.bump).to_string();
+    let api_bump = VersionBump::from_str(&api_evidence.bump);
+    let api_evidence_bump = bump_label(api_bump).to_string();
+    let mut final_bump = commit_decision.bump;
+    let mut waiver = waiver_not_required();
+
+    let reconciliation = match api_evidence.status.as_str() {
+        "findings" => match (commit_decision.bump, api_bump) {
+            (_, Some(api_bump)) if commit_decision.bump.is_none_or(|floor| api_bump > floor) => {
+                final_bump = Some(api_bump);
+                "upgraded"
+            }
+            (Some(floor), Some(api_bump)) if api_bump == floor => "agreed",
+            (Some(_), Some(_)) => {
+                waiver = missing_version_intent_waiver(&commit_bump, &api_evidence_bump);
+                "conflict"
+            }
+            _ => "unverified",
+        },
+        "passed" if commit_decision.bump == Some(VersionBump::Major) => {
+            waiver = missing_version_intent_waiver(&commit_bump, "none");
+            "conflict"
+        }
+        "passed" => "compatible",
+        "skipped" => "unavailable",
+        "failed" => "unverified",
+        _ => "unverified",
+    }
+    .to_string();
+
+    let mut decisive_signals = Vec::new();
+    if let Some(commit) = &commit_decision.decisive {
+        decisive_signals.push(format!("commit:{}", commit.evidence_line()));
+    }
+    decisive_signals.push(format!(
+        "api-evidence:{} {} {}",
+        api_evidence.provider, api_evidence.status, api_evidence.summary
+    ));
+
+    ReconciledVersionDecision {
+        bump: final_bump,
+        decisive: commit_decision.decisive,
+        unknown_commits: commit_decision.unknown_commits,
+        commit_bump,
+        api_evidence_bump,
+        reconciliation,
+        decisive_signals,
+        api_evidence,
+        waiver,
+    }
+}
+
+fn bump_label(bump: Option<VersionBump>) -> &'static str {
+    bump.map(VersionBump::as_str).unwrap_or("none")
+}
+
+fn waiver_not_required() -> VersionDecisionWaiver {
+    VersionDecisionWaiver {
+        required: false,
+        status: "not-required".into(),
+        kind: String::new(),
+        reason: String::new(),
+    }
+}
+
+fn missing_version_intent_waiver(commit_bump: &str, api_bump: &str) -> VersionDecisionWaiver {
+    VersionDecisionWaiver {
+        required: true,
+        status: "missing".into(),
+        kind: "version-intent-policy".into(),
+        reason: format!(
+            "commit-derived bump `{commit_bump}` conflicts with public API evidence `{api_bump}`; a typed version-intent waiver or human review is required"
+        ),
+    }
+}

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -39,7 +39,10 @@ release. A normal local run writes the same release-kit artifact to
 `.landmark/run/release-kit.json` and records its schema and hash in
 `.landmark/run/evidence.json`. The evidence packet also carries the
 deterministic version decision and changed-file list for producer adapters that
-need text evidence without re-reading the repository.
+need text evidence without re-reading the repository. Rust crate repositories
+also record `cargo-semver-checks` public API evidence against the previous
+release tag when the provider can run; skips and tool failures are explicit
+evidence statuses, not silent omissions.
 
 For a GitHub-backed pipeline, keep publication explicit:
 
@@ -130,7 +133,7 @@ rich media and publication-specific outputs should stay adapter-owned.
 | audience | Built-in prompt variant: `general`, `developer`, `end-user`, `enterprise` |
 | synthesis-required | If `true`, fail the action when synthesis or publication policy fails |
 | preflight check | Pre-`semantic-release` validation: tag history integrity, config detection (`landmark preflight-tags`) |
-| version decision | The output of the shared version-decision engine (`crates/landmark/src/version_decision.rs`): a bump plus the decisive commit and any unknown (non-conventional) commits it named rather than silently absorbed |
+| version decision | The output of the shared version-decision engine (`crates/landmark/src/version_decision.rs`): the final bump, commit-derived floor, public API evidence bump, reconciliation status, decisive signals, unknown commits, and any typed waiver state |
 | release kit | Typed packet of release facts, recommended outputs, artifact status, provenance, approvals, and producer contracts |
 | producer adapter | Explicit local, browser, service, harness, or human boundary that turns release-kit inputs into a rich artifact such as a video, GIF, image, essay, docs patch, or blog draft |
 | final-mile artifact | Any output needed to ship the release beyond versioning: docs updates, migration guide, demo script, video, GIF, image, blog post, announcement copy, feed item, or social copy |

--- a/schemas/release-kit.v1.schema.json
+++ b/schemas/release-kit.v1.schema.json
@@ -10,7 +10,63 @@
     "schema_version": { "type": "string", "const": "landmark.release-kit.v1" },
     "generated_at": { "type": "string" },
     "product": { "type": "object" },
-    "release": { "type": "object" },
+    "release": {
+      "type": "object",
+      "required": ["tag", "version", "previous_tag", "repository", "release_url", "version_decision"],
+      "properties": {
+        "tag": { "type": "string" },
+        "version": { "type": "string" },
+        "previous_tag": { "type": "string" },
+        "repository": { "type": "string" },
+        "release_url": { "type": "string" },
+        "version_decision": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["latest_tag", "bump", "commit_bump", "api_evidence_bump", "reconciliation", "commit_count", "conventional_commit_count", "range", "decisive_commit", "decisive_signals", "unknown_commits", "api_evidence", "waiver"],
+          "properties": {
+            "latest_tag": { "type": "string" },
+            "bump": { "type": "string", "enum": ["major", "minor", "patch", "none"] },
+            "commit_bump": { "type": "string", "enum": ["major", "minor", "patch", "none"] },
+            "api_evidence_bump": { "type": "string", "enum": ["major", "minor", "patch", "none"] },
+            "reconciliation": { "type": "string", "enum": ["agreed", "compatible", "upgraded", "conflict", "unavailable", "unverified"] },
+            "commit_count": { "type": "integer" },
+            "conventional_commit_count": { "type": "integer" },
+            "range": { "type": "string" },
+            "decisive_commit": { "type": ["string", "null"] },
+            "decisive_signals": { "type": "array", "items": { "type": "string" } },
+            "unknown_commits": { "type": "array", "items": { "type": "string" } },
+            "api_evidence": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["provider", "status", "bump", "baseline", "target", "command", "exit_code", "summary", "findings", "failure_message"],
+              "properties": {
+                "provider": { "type": "string" },
+                "status": { "type": "string", "enum": ["skipped", "passed", "findings", "failed"] },
+                "bump": { "type": "string", "enum": ["major", "minor", "patch", "none"] },
+                "baseline": { "type": "string" },
+                "target": { "type": "string" },
+                "command": { "type": "string" },
+                "exit_code": { "type": "integer" },
+                "summary": { "type": "string" },
+                "findings": { "type": "array", "items": { "type": "string" } },
+                "failure_message": { "type": "string" }
+              }
+            },
+            "waiver": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["required", "status", "kind", "reason"],
+              "properties": {
+                "required": { "type": "boolean" },
+                "status": { "type": "string", "enum": ["not-required", "missing", "accepted"] },
+                "kind": { "type": "string" },
+                "reason": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
     "classification": {
       "type": "object",
       "additionalProperties": false,

--- a/schemas/run-evidence.v1.schema.json
+++ b/schemas/run-evidence.v1.schema.json
@@ -19,15 +19,47 @@
     "notes_sha256": { "type": "string" },
     "version_decision": {
       "type": "object",
-      "required": ["latest_tag", "bump", "commit_count", "conventional_commit_count", "range", "decisive_commit", "unknown_commits"],
+      "required": ["latest_tag", "bump", "commit_bump", "api_evidence_bump", "reconciliation", "commit_count", "conventional_commit_count", "range", "decisive_commit", "decisive_signals", "unknown_commits", "api_evidence", "waiver"],
       "properties": {
         "latest_tag": { "type": "string" },
         "bump": { "type": "string", "enum": ["major", "minor", "patch", "none"] },
+        "commit_bump": { "type": "string", "enum": ["major", "minor", "patch", "none"] },
+        "api_evidence_bump": { "type": "string", "enum": ["major", "minor", "patch", "none"] },
+        "reconciliation": { "type": "string", "enum": ["agreed", "compatible", "upgraded", "conflict", "unavailable", "unverified"] },
         "commit_count": { "type": "integer", "minimum": 0 },
         "conventional_commit_count": { "type": "integer", "minimum": 0 },
         "range": { "type": "string" },
         "decisive_commit": { "type": ["string", "null"] },
-        "unknown_commits": { "type": "array", "items": { "type": "string" } }
+        "decisive_signals": { "type": "array", "items": { "type": "string" } },
+        "unknown_commits": { "type": "array", "items": { "type": "string" } },
+        "api_evidence": {
+          "type": "object",
+          "required": ["provider", "status", "bump", "baseline", "target", "command", "exit_code", "summary", "findings", "failure_message"],
+          "properties": {
+            "provider": { "type": "string" },
+            "status": { "type": "string", "enum": ["skipped", "passed", "findings", "failed"] },
+            "bump": { "type": "string", "enum": ["major", "minor", "patch", "none"] },
+            "baseline": { "type": "string" },
+            "target": { "type": "string" },
+            "command": { "type": "string" },
+            "exit_code": { "type": "integer" },
+            "summary": { "type": "string" },
+            "findings": { "type": "array", "items": { "type": "string" } },
+            "failure_message": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "waiver": {
+          "type": "object",
+          "required": ["required", "status", "kind", "reason"],
+          "properties": {
+            "required": { "type": "boolean" },
+            "status": { "type": "string", "enum": ["not-required", "missing", "accepted"] },
+            "kind": { "type": "string" },
+            "reason": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": false
     },


### PR DESCRIPTION
## Summary

- Adds a Rust API-evidence provider seam and a `cargo semver-checks --baseline-rev <previous-tag>` provider for Rust crate repos.
- Reconciles conventional-commit floor, public API evidence, and minimal typed waiver/conflict state in the shared version decision.
- Carries the new decision fields through run-evidence, release-kit, release-feed enrichment, schemas, docs, and replay.

## Decision Flow

Before:

```text
git range -> classify commits -> highest conventional bump -> release tag
```

After:

```text
git range -> classify commits -> deterministic floor
          -> API evidence provider
          -> reconciliation:
             agreed / compatible / upgraded / conflict / unavailable / unverified
          -> release tag + run-evidence + release-kit decisive signals
```

## 002 Waiver Cut

This does not implement the full `backlog.d/002` manifest/CLI version-intent override. It implements the minimal primitive 005 needs now: `version_decision.waiver` records whether a typed version-intent policy waiver is required, missing, or not required when commit and API evidence conflict. Full operator-supplied policy overrides stay in 002.

## Verification

- `cargo test --locked -p landmark version_decision_tests -- --nocapture`
- `cargo test --locked -p landmark release_feed_tests -- --nocapture`
- `cargo run --locked -p landmark -- replay-action --scenario semver_evidence_agrees --scenario semver_evidence_upgrades --scenario semver_evidence_absent --scenario semver_evidence_tool_failure --scenario release_feed_adapter --evidence-dir .landmark/replay-semver-feed-focused`
- `bin/gate`
- `bin/replay-action --evidence-dir .landmark/replay-full-explicit`

Full replay passed 34 scenarios. Semver evidence scenarios covered:

- `semver_evidence_agrees`: explicit `--release-tag v2.0.0` at HEAD, API findings agree with major.
- `semver_evidence_upgrades`: feat commit floor minor, API findings upgrade to major.
- `semver_evidence_absent`: non-Rust repo records unavailable/no-provider skip.
- `semver_evidence_tool_failure`: tool failure records unverified and keeps patch floor.

## Review

Fresh-context critic initially found two blockers: explicit release-tag paths skipped API evidence, and release-feed could carry old-shaped version decisions. Both were fixed. Narrow re-review cleared the blockers; residual non-blocking concern is adding a future dirty-worktree guard for local release runs.

Agent: codex-implementer
Agent-Surface: Codex CLI
Agent-Runner: codex
Agent-Model: GPT-5
Agent-Task: backlog.d/005-build-diff-grounded-semver-evidence.md
