### PR TITLE
feat(release): export static public release entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ writes markdown, plaintext, HTML, JSON, and RSS release artifacts under
 `--dry-run` can print the complete final-mile artifact graph without writing
 files.
 
+The JSON artifact is the zero-runtime marketing-site export. Each
+`docs/releases/releases.json` entry declares
+`schema_version: landmark.public-release-notes.v1` plus `repository`,
+`release_url`, `audience`, `markdown`, `html`, `plaintext`, and parsed
+`sections`, so a static site can render the latest public notes without loading
+Landmark or re-reading git history.
+
 Build from source with `cargo run --locked -- ...` or a locally built
 `target/debug/landmark`, or download a published per-target release binary
 (`landmark-x86_64-unknown-linux-musl`, `landmark-aarch64-unknown-linux-musl`,

--- a/crates/landmark/src/cli.rs
+++ b/crates/landmark/src/cli.rs
@@ -317,6 +317,12 @@ pub(crate) struct WriteArtifactsArgs {
     pub(crate) notes_file: PathBuf,
     #[arg(long)]
     pub(crate) version: String,
+    #[arg(long, default_value = "")]
+    pub(crate) repository: String,
+    #[arg(long = "release-url", default_value = "")]
+    pub(crate) release_url: String,
+    #[arg(long, default_value = "")]
+    pub(crate) audience: String,
     #[arg(long = "output-file", default_value = "")]
     pub(crate) output_file: String,
     #[arg(long = "output-text-file", default_value = "")]

--- a/crates/landmark/src/main.rs
+++ b/crates/landmark/src/main.rs
@@ -29,6 +29,8 @@ mod extract_prs_tests;
 mod manifest;
 mod pr_range;
 mod providers;
+#[cfg(test)]
+mod release_artifact_tests;
 mod release_body;
 mod release_classification;
 #[cfg(test)]

--- a/crates/landmark/src/release_artifact_tests.rs
+++ b/crates/landmark/src/release_artifact_tests.rs
@@ -1,0 +1,128 @@
+use super::*;
+
+#[test]
+fn markdown_filters_unsafe_links() {
+    let html = markdown_to_html_fragment("[bad](javascript:alert(1)) [ok](https://example.com)");
+    assert!(html.contains("href=\"#\""));
+    assert!(html.contains("href=\"https://example.com\""));
+}
+
+#[test]
+fn typed_artifact_renders_shared_outputs() {
+    let artifact = ReleaseNoteArtifact::from_markdown(
+        "v1.2.3",
+        "## Added\n\n- See [docs](https://example.com) and [bad](javascript:alert(1))",
+    );
+    assert_eq!(artifact.version, "1.2.3");
+    assert!(artifact.html.contains("href=\"https://example.com\""));
+    assert!(artifact.html.contains("href=\"#\""));
+    assert!(artifact.plaintext.contains("See docs and bad"));
+    assert!(artifact.slack.contains("<https://example.com|docs>"));
+    assert!(!artifact.slack.contains("javascript:"));
+    assert_eq!(artifact.sections[0].title, "Added");
+    assert_eq!(
+        artifact.sections[0].bullets[0].links[0].href,
+        "https://example.com"
+    );
+    let context = ReleaseNoteEntryContext::new(
+        "misty-step/example",
+        "https://github.com/misty-step/example/releases/tag/v1.2.3",
+        "end-user",
+    );
+    let entry = artifact.json_entry(&context);
+    assert_eq!(entry["schema_version"], "landmark.public-release-notes.v1");
+    assert_eq!(entry["repository"], "misty-step/example");
+    assert_eq!(entry["audience"], "end-user");
+    assert!(entry["sections"].is_array());
+}
+
+#[test]
+fn public_notes_skip_internal_process_commits() {
+    let feature = RunCommit {
+        subject: "feat(cli): add portable release run".into(),
+        short_hash: "abc1234".into(),
+        body: String::new(),
+    };
+    let internal = RunCommit {
+        subject: "chore(ci): refresh agent lane".into(),
+        short_hash: "def5678".into(),
+        body: String::new(),
+    };
+    let scoped_process_feature = RunCommit {
+        subject: "feat(ci): refresh agent lane".into(),
+        short_hash: "fed9012".into(),
+        body: String::new(),
+    };
+    let internal_revert = RunCommit {
+        subject: "Revert \"chore(ci): refresh agent lane\"".into(),
+        short_hash: "9999999".into(),
+        body: String::new(),
+    };
+    let public_fix = RunCommit {
+        subject: "fix(ui): keep release cards readable".into(),
+        short_hash: "1111111".into(),
+        body: String::new(),
+    };
+
+    assert_eq!(
+        public_note_for_commit(&feature).as_deref(),
+        Some("Add portable release run")
+    );
+    assert_eq!(public_note_for_commit(&internal), None);
+    assert_eq!(public_note_for_commit(&scoped_process_feature), None);
+    assert_eq!(public_note_for_commit(&internal_revert), None);
+    assert_eq!(
+        public_note_for_commit(&public_fix).as_deref(),
+        Some("Keep release cards readable")
+    );
+}
+
+#[test]
+fn backfill_release_urls_follow_api_base_url() {
+    assert_eq!(
+        github_server_url_from_api("https://api.github.com"),
+        "https://github.com"
+    );
+    assert_eq!(
+        github_server_url_from_api("https://github.example.com/api/v3"),
+        "https://github.example.com"
+    );
+}
+
+#[test]
+fn backfill_feed_channel_uses_api_base_url() {
+    let repo = tempfile::tempdir().unwrap();
+    let args = BackfillArgs {
+        repo_root: repo.path().to_path_buf(),
+        since: String::new(),
+        mode: "artifacts-only".into(),
+        dry_run: false,
+        repository: "owner/repo".into(),
+        github_token: String::new(),
+        api_base_url: "https://github.example.com/api/v3".into(),
+        confirm_release_body: false,
+        max_tags: 0,
+        output_file: String::new(),
+        output_text_file: String::new(),
+        output_html_file: String::new(),
+        output_json: String::new(),
+        rss_feed_file: "feed.xml".into(),
+        rss_max_entries: 50,
+        resume_file: PathBuf::new(),
+    };
+    backfill_write_feed(
+        &args,
+        "owner/repo",
+        vec![FeedItem {
+            title: "owner/repo v1.0.0".into(),
+            link: "https://github.example.com/owner/repo/releases/tag/v1.0.0".into(),
+            guid: "v1.0.0".into(),
+            description: "<p>Release</p>".into(),
+            pub_date: "Sat, 04 Jul 2026 00:00:00 +0000".into(),
+        }],
+    )
+    .unwrap();
+
+    let feed = fs::read_to_string(repo.path().join("feed.xml")).unwrap();
+    assert!(feed.contains("<link>https://github.example.com/owner/repo</link>"));
+}

--- a/crates/landmark/src/release_ops/artifacts.rs
+++ b/crates/landmark/src/release_ops/artifacts.rs
@@ -6,7 +6,11 @@ pub(crate) fn write_notes_file(content: &str, template: &str, version: &str) -> 
     Ok(path)
 }
 
-pub(crate) fn append_json_entry(template: &str, artifact: &ReleaseNoteArtifact) -> Result<()> {
+pub(crate) fn append_json_entry(
+    template: &str,
+    artifact: &ReleaseNoteArtifact,
+    context: &ReleaseNoteEntryContext,
+) -> Result<()> {
     let path = PathBuf::from(template.replace("{version}", &artifact.tag));
     let mut entries = if path.is_file() {
         serde_json::from_str::<Vec<Value>>(&fs::read_to_string(&path)?)?
@@ -17,7 +21,7 @@ pub(crate) fn append_json_entry(template: &str, artifact: &ReleaseNoteArtifact) 
         entry["tag"].as_str() != Some(&artifact.tag)
             && entry["version"].as_str() != Some(&artifact.version)
     });
-    entries.push(artifact.json_entry());
+    entries.push(artifact.json_entry(context));
     ensure_parent(&path)?;
     fs::write(path, serde_json::to_string_pretty(&entries)? + "\n")?;
     Ok(())

--- a/crates/landmark/src/release_ops/backfill.rs
+++ b/crates/landmark/src/release_ops/backfill.rs
@@ -404,6 +404,23 @@ pub(crate) fn backfill_write_artifacts(
     feed_items: &mut Vec<FeedItem>,
 ) -> Result<BackfillArtifactRecord> {
     let artifact = ReleaseNoteArtifact::from_markdown(&tag.tag, notes);
+    let manifest =
+        load_manifest(&args.repo_root)?.unwrap_or_else(|| infer_manifest(&args.repo_root));
+    let audience = manifest
+        .audience
+        .as_deref()
+        .and_then(trimmed_option)
+        .unwrap_or_else(|| "general".into());
+    let release_url = if repository.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "{}/{repository}/releases/tag/{}",
+            github_server_url_from_api(&args.api_base_url),
+            tag.tag
+        )
+    };
+    let entry_context = ReleaseNoteEntryContext::new(repository, &release_url, &audience);
     let markdown = backfill_write_template_if_requested(
         &args.repo_root,
         &args.output_file,
@@ -425,12 +442,12 @@ pub(crate) fn backfill_write_artifacts(
     let json_path = if args.output_json.trim().is_empty() {
         PathBuf::new()
     } else {
-        backfill_append_json(&args.repo_root, &args.output_json, &artifact)?
-    };
-    let release_url = if repository.is_empty() {
-        String::new()
-    } else {
-        format!("https://github.com/{repository}/releases/tag/{}", tag.tag)
+        backfill_append_json(
+            &args.repo_root,
+            &args.output_json,
+            &artifact,
+            &entry_context,
+        )?
     };
     if !args.rss_feed_file.trim().is_empty() {
         feed_items.retain(|item| item.guid != tag.tag);
@@ -508,6 +525,7 @@ pub(crate) fn backfill_append_json(
     repo_root: &Path,
     template: &str,
     artifact: &ReleaseNoteArtifact,
+    context: &ReleaseNoteEntryContext,
 ) -> Result<PathBuf> {
     let path = repo_root.join(template.replace("{version}", &artifact.tag));
     let mut entries = if path.is_file() {
@@ -519,7 +537,7 @@ pub(crate) fn backfill_append_json(
         entry["tag"].as_str() != Some(&artifact.tag)
             && entry["version"].as_str() != Some(&artifact.version)
     });
-    entries.insert(0, artifact.json_entry());
+    entries.insert(0, artifact.json_entry(context));
     ensure_parent(&path)?;
     fs::write(&path, serde_json::to_string_pretty(&entries)? + "\n")?;
     Ok(path)
@@ -534,11 +552,17 @@ pub(crate) fn backfill_write_feed(
         return Ok(());
     }
     let path = args.repo_root.join(&args.rss_feed_file);
+    let channel_link = if repository.is_empty() {
+        default_release_url_base(repository)
+    } else {
+        format!(
+            "{}/{}",
+            github_server_url_from_api(&args.api_base_url),
+            repository
+        )
+    };
     ensure_parent(&path)?;
-    fs::write(
-        path,
-        render_feed(repository, &default_release_url_base(repository), &items),
-    )?;
+    fs::write(path, render_feed(repository, &channel_link, &items))?;
     Ok(())
 }
 
@@ -569,6 +593,17 @@ pub(crate) fn backfill_update_release_body(
         )
         .into())
     }
+}
+
+pub(crate) fn github_server_url_from_api(api_base_url: &str) -> String {
+    let trimmed = api_base_url.trim().trim_end_matches('/');
+    if trimmed == "https://api.github.com" || trimmed == "http://api.github.com" {
+        return trimmed.replace("api.github.com", "github.com");
+    }
+    if let Some(server) = trimmed.strip_suffix("/api/v3") {
+        return server.to_string();
+    }
+    trimmed.to_string()
 }
 
 pub(crate) fn estimate_prompt_tokens(text: &str) -> usize {

--- a/crates/landmark/src/release_ops/models.rs
+++ b/crates/landmark/src/release_ops/models.rs
@@ -11,6 +11,13 @@ pub(crate) struct ReleaseNoteArtifact {
     published_at: String,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct ReleaseNoteEntryContext {
+    pub(crate) repository: String,
+    pub(crate) release_url: String,
+    pub(crate) audience: String,
+}
+
 #[derive(Clone, Serialize)]
 pub(crate) struct NoteSection {
     pub(crate) title: String,
@@ -44,10 +51,14 @@ impl ReleaseNoteArtifact {
         }
     }
 
-    pub(crate) fn json_entry(&self) -> Value {
+    pub(crate) fn json_entry(&self, context: &ReleaseNoteEntryContext) -> Value {
         json!({
+            "schema_version": "landmark.public-release-notes.v1",
             "version": self.version,
             "tag": self.tag,
+            "repository": context.repository,
+            "release_url": context.release_url,
+            "audience": context.audience,
             "notes": self.notes,
             "markdown": self.notes,
             "html": self.html,
@@ -83,6 +94,16 @@ impl ReleaseNoteArtifact {
     }
 }
 
+impl ReleaseNoteEntryContext {
+    pub(crate) fn new(repository: &str, release_url: &str, audience: &str) -> Self {
+        Self {
+            repository: repository.trim().to_string(),
+            release_url: release_url.trim().to_string(),
+            audience: trimmed_option(audience).unwrap_or_else(|| "general".into()),
+        }
+    }
+}
+
 #[derive(Serialize)]
 pub(crate) struct SynthesisStatus {
     pub(crate) synthesis_enabled: bool,
@@ -107,6 +128,25 @@ pub(crate) struct DestinationStatus {
 pub(crate) fn write_artifacts(args: WriteArtifactsArgs) -> Result<()> {
     let notes = read_nonempty(&args.notes_file)?;
     let artifact = ReleaseNoteArtifact::from_markdown(&args.version, &notes);
+    let repository = trimmed_option(&args.repository)
+        .or_else(|| {
+            env::var("GITHUB_REPOSITORY")
+                .ok()
+                .and_then(|value| trimmed_option(&value))
+        })
+        .unwrap_or_default();
+    let release_url = trimmed_option(&args.release_url).unwrap_or_else(|| {
+        if repository.is_empty() {
+            String::new()
+        } else {
+            release_link(
+                &default_release_url_base(&repository),
+                &repository,
+                &args.version,
+            )
+        }
+    });
+    let context = ReleaseNoteEntryContext::new(&repository, &release_url, &args.audience);
     if !args.output_file.trim().is_empty() {
         write_notes_file(&artifact.notes, &args.output_file, &args.version)?;
     }
@@ -117,7 +157,7 @@ pub(crate) fn write_artifacts(args: WriteArtifactsArgs) -> Result<()> {
         write_notes_file(&artifact.html, &args.output_html_file, &args.version)?;
     }
     if !args.output_json.trim().is_empty() {
-        append_json_entry(&args.output_json, &artifact)?;
+        append_json_entry(&args.output_json, &artifact, &context)?;
     }
     print!("{}", artifact.notes);
     Ok(())

--- a/crates/landmark/src/release_ops/run.rs
+++ b/crates/landmark/src/release_ops/run.rs
@@ -208,6 +208,14 @@ pub(crate) fn conventional_commit_type(subject: &str) -> Option<&str> {
     }
 }
 
+pub(crate) fn conventional_commit_scope(subject: &str) -> Option<&str> {
+    let subject = subject.trim();
+    let header = subject.split(':').next()?.trim_end_matches('!');
+    let scope_start = header.find('(')?;
+    let scope_end = header[scope_start + 1..].find(')')? + scope_start + 1;
+    Some(&header[scope_start + 1..scope_end])
+}
+
 pub(crate) fn is_breaking_commit(commit: &RunCommit) -> bool {
     commit.subject.contains("!:")
         || commit.subject.contains(")!:")
@@ -279,13 +287,81 @@ pub(crate) fn render_local_public_notes(
             "- {product} has no user-visible commit entries in this release range.\n"
         ));
     } else {
-        for commit in &release.commits {
+        let public_notes: Vec<_> = release
+            .commits
+            .iter()
+            .filter_map(public_note_for_commit)
+            .collect();
+        if public_notes.is_empty() {
+            markdown.push_str(&format!(
+                "- {product} shipped maintenance changes with no user-visible release notes.\n"
+            ));
+            return markdown;
+        }
+        for note in public_notes {
             markdown.push_str("- ");
-            markdown.push_str(&humanize_commit_subject(&commit.subject));
+            markdown.push_str(&note);
             markdown.push('\n');
         }
     }
     markdown
+}
+
+pub(crate) fn public_note_for_commit(commit: &RunCommit) -> Option<String> {
+    let subject = commit.subject.trim();
+    if internal_process_subject(subject) {
+        return None;
+    }
+    if let Some(reverted) = reverted_subject(subject)
+        && internal_process_subject(reverted)
+    {
+        return None;
+    }
+    if is_breaking_commit(commit) {
+        return Some(humanize_commit_subject(subject));
+    }
+    if subject.starts_with("revert:") || subject.starts_with("Revert ") {
+        return Some(humanize_commit_subject(subject));
+    }
+    match conventional_commit_type(subject) {
+        Some("feat" | "fix" | "perf") => Some(humanize_commit_subject(subject)),
+        _ => None,
+    }
+}
+
+pub(crate) fn internal_process_subject(subject: &str) -> bool {
+    let internal_types = ["build", "chore", "ci", "refactor", "style", "test", "tests"];
+    let internal_scopes = [
+        "agent",
+        "agents",
+        "build",
+        "ci",
+        "dependency",
+        "dependencies",
+        "deps",
+        "dev",
+        "infra",
+        "internal",
+        "test",
+        "tests",
+        "workflow",
+        "workflows",
+    ];
+    conventional_commit_type(subject).is_some_and(|kind| internal_types.contains(&kind))
+        || conventional_commit_scope(subject).is_some_and(|scope| {
+            internal_scopes.contains(&scope.trim().to_ascii_lowercase().as_str())
+        })
+}
+
+pub(crate) fn reverted_subject(subject: &str) -> Option<&str> {
+    let subject = subject.trim();
+    if let Some(rest) = subject.strip_prefix("revert:") {
+        return Some(rest.trim());
+    }
+    subject
+        .strip_prefix("Revert \"")
+        .and_then(|rest| rest.strip_suffix('"'))
+        .map(str::trim)
 }
 
 impl RunCommit {
@@ -321,6 +397,14 @@ pub(crate) fn write_run_artifacts(
     notes: &str,
 ) -> Result<RunArtifactRecord> {
     let artifact = ReleaseNoteArtifact::from_markdown(release_tag, notes);
+    let public_notes_audience = manifest
+        .audience
+        .as_deref()
+        .and_then(trimmed_option)
+        .unwrap_or_else(|| "general".into());
+    let release_url = release_link(release_url_base, repository, release_tag);
+    let entry_context =
+        ReleaseNoteEntryContext::new(repository, &release_url, &public_notes_audience);
     let technical = run_template_path(&args.repo_root, &args.technical_changelog_file, release_tag);
     if !args.dry_run && !technical.as_os_str().is_empty() {
         write_path(&technical, technical_changelog)?;
@@ -342,7 +426,12 @@ pub(crate) fn write_run_artifacts(
     } else if args.dry_run {
         run_template_path(&args.repo_root, &args.output_json, release_tag)
     } else {
-        backfill_append_json(&args.repo_root, &args.output_json, &artifact)?
+        backfill_append_json(
+            &args.repo_root,
+            &args.output_json,
+            &artifact,
+            &entry_context,
+        )?
     };
     let rss_path = if args.rss_feed_file.trim().is_empty() {
         PathBuf::new()
@@ -357,7 +446,7 @@ pub(crate) fn write_run_artifacts(
             0,
             FeedItem {
                 title: format!("{repository} {release_tag}"),
-                link: release_link(release_url_base, repository, release_tag),
+                link: release_url.clone(),
                 guid: release_tag.to_string(),
                 description: artifact.html,
                 pub_date: Utc::now().to_rfc2822(),
@@ -375,11 +464,7 @@ pub(crate) fn write_run_artifacts(
         technical_changelog_audience: "internal-developer-operator".into(),
         technical_changelog_schema: "landmark.internal-technical-changelog.v1".into(),
         markdown: markdown.display().to_string(),
-        public_notes_audience: manifest
-            .audience
-            .as_deref()
-            .and_then(trimmed_option)
-            .unwrap_or_else(|| "general".into()),
+        public_notes_audience,
         public_notes_schema: "landmark.public-release-notes.v1".into(),
         plaintext: plaintext.display().to_string(),
         html: html.display().to_string(),

--- a/crates/landmark/src/replay/provider_scenarios/provider_runs.rs
+++ b/crates/landmark/src/replay/provider_scenarios/provider_runs.rs
@@ -79,6 +79,13 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
         ["commit", "-q", "-m", "feat(cli): add portable release run"],
         &repo,
     )?;
+    fs::write(repo.join("lane.txt"), "agent lane maintenance\n")?;
+    run_ok("git", ["add", "lane.txt"], &repo)?;
+    run_ok(
+        "git",
+        ["commit", "-q", "-m", "chore(ci): refresh agent lane"],
+        &repo,
+    )?;
     let result = Command::new(current_exe())
         .args([
             "run",
@@ -164,9 +171,44 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
     if !notes.contains("Add portable release run") {
         return Err("local run release notes did not include the feature commit".into());
     }
+    let releases: Value = serde_json::from_str(&fs::read_to_string(&json_path)?)?;
+    let entry = releases
+        .as_array()
+        .and_then(|entries| entries.first())
+        .ok_or("local run release JSON did not include a release entry")?;
+    assert_public_release_entry_contract(entry)?;
+    if entry["schema_version"] != "landmark.public-release-notes.v1"
+        || entry["repository"] != "local-provider-run"
+        || entry["release_url"] != "local://local-provider-run/releases/v1.1.0"
+        || entry["audience"] != "general"
+    {
+        return Err(format!(
+            "local run release JSON is not a self-contained public site artifact: {entry}"
+        )
+        .into());
+    }
+    let entry_text = serde_json::to_string(entry)?;
+    for leaked in ["feat(", "chore(ci)", "agent lane", "Technical Changelog"] {
+        if entry_text.contains(leaked) {
+            return Err(format!(
+                "local run release JSON leaked internal release-process detail `{leaked}`: {entry_text}"
+            )
+            .into());
+        }
+    }
+    let plaintext = entry["plaintext"].as_str().unwrap_or_default();
+    if plaintext.contains("Technical Changelog") {
+        return Err(format!(
+            "local run release JSON leaked internal release-process detail: {plaintext}"
+        )
+        .into());
+    }
     let technical = fs::read_to_string(repo.join(".landmark/run/technical.md"))?;
     if !technical.contains("feat(cli): add portable release run") {
         return Err("local run technical changelog did not include the raw commit".into());
+    }
+    if !technical.contains("chore(ci): refresh agent lane") {
+        return Err("local run technical changelog dropped the internal commit".into());
     }
     run_ok("git", ["tag", "v1.1.0"], &repo)?;
     fs::write(repo.join("after-release.txt"), "post release work\n")?;
@@ -219,7 +261,7 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
         )
         .into());
     }
-    if tagged_evidence["version_decision"]["commit_count"] != 1 {
+    if tagged_evidence["version_decision"]["commit_count"] != 2 {
         return Err("existing-tag run included commits outside the tagged range".into());
     }
     let tagged_technical = fs::read_to_string(repo.join(".landmark/tagged-run/technical.md"))?;
@@ -394,6 +436,48 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
             "release_kit": release_kit,
         }
     }))
+}
+
+pub(crate) fn assert_public_release_entry_contract(entry: &Value) -> Result<()> {
+    let schema: Value = serde_json::from_str(include_str!(
+        "../../../../../schemas/release-entry.v1.schema.json"
+    ))?;
+    let required = schema["required"]
+        .as_array()
+        .ok_or("release-entry schema missing required field list")?;
+    for field in required {
+        let field = field
+            .as_str()
+            .ok_or("release-entry required field was not a string")?;
+        if entry.get(field).is_none() {
+            return Err(
+                format!("public release entry missing schema-required field `{field}`").into(),
+            );
+        }
+    }
+    for field in ["schema_version", "repository", "release_url", "audience"] {
+        if entry[field].as_str().unwrap_or_default().trim().is_empty() {
+            return Err(format!("public release entry missing static-site field `{field}`").into());
+        }
+    }
+    for field in [
+        "version",
+        "tag",
+        "notes",
+        "markdown",
+        "html",
+        "plaintext",
+        "slack",
+        "published_at",
+    ] {
+        if entry[field].as_str().unwrap_or_default().trim().is_empty() {
+            return Err(format!("public release entry has empty required field `{field}`").into());
+        }
+    }
+    if entry["sections"].as_array().is_none_or(Vec::is_empty) {
+        return Err("public release entry has no parsed sections".into());
+    }
+    Ok(())
 }
 
 pub(crate) fn scenario_github_provider_run(tmp_root: &Path) -> Result<Value> {

--- a/crates/landmark/src/tests.rs
+++ b/crates/landmark/src/tests.rs
@@ -58,33 +58,6 @@ fn release_body_synthesis_is_idempotent_across_reruns() {
 }
 
 #[test]
-fn markdown_filters_unsafe_links() {
-    let html = markdown_to_html_fragment("[bad](javascript:alert(1)) [ok](https://example.com)");
-    assert!(html.contains("href=\"#\""));
-    assert!(html.contains("href=\"https://example.com\""));
-}
-
-#[test]
-fn typed_artifact_renders_shared_outputs() {
-    let artifact = ReleaseNoteArtifact::from_markdown(
-        "v1.2.3",
-        "## Added\n\n- See [docs](https://example.com) and [bad](javascript:alert(1))",
-    );
-    assert_eq!(artifact.version, "1.2.3");
-    assert!(artifact.html.contains("href=\"https://example.com\""));
-    assert!(artifact.html.contains("href=\"#\""));
-    assert!(artifact.plaintext.contains("See docs and bad"));
-    assert!(artifact.slack.contains("<https://example.com|docs>"));
-    assert!(!artifact.slack.contains("javascript:"));
-    assert_eq!(artifact.sections[0].title, "Added");
-    assert_eq!(
-        artifact.sections[0].bullets[0].links[0].href,
-        "https://example.com"
-    );
-    assert!(artifact.json_entry()["sections"].is_array());
-}
-
-#[test]
 fn next_release_tag_bumps_from_latest() {
     let latest = BackfillTag {
         tag: "v1.2.3".into(),

--- a/schemas/release-entry.v1.schema.json
+++ b/schemas/release-entry.v1.schema.json
@@ -7,8 +7,12 @@
   "x-landmark-artifact": "release notes JSON entry",
   "required": ["version", "tag", "notes", "markdown", "html", "plaintext", "slack", "sections", "published_at"],
   "properties": {
+    "schema_version": { "type": "string", "const": "landmark.public-release-notes.v1" },
     "version": { "type": "string" },
     "tag": { "type": "string" },
+    "repository": { "type": "string" },
+    "release_url": { "type": "string" },
+    "audience": { "type": "string" },
     "notes": { "type": "string" },
     "markdown": { "type": "string" },
     "html": { "type": "string" },


### PR DESCRIPTION
## Summary

- Adds static-site metadata to release-note JSON entries: `schema_version`, `repository`, `release_url`, and `audience`.
- Keeps `release-entry.v1` backward-compatible by making the new fields additive, not schema-required for older entries.
- Filters internal/process scoped commits out of generated public local notes while preserving them in the technical changelog.
- Adds replay and unit coverage for the public JSON contract, no-leak fixture, and GitHub Enterprise backfill/feed URLs.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked -p landmark release_artifact_tests`
- `cargo run --locked -p landmark -- replay-action --scenario local_provider_run --scenario provider_run_parity --evidence-dir /tmp/landmark-902-replay`
- `bin/gate`
- Full replay evidence: `.landmark/replay/replay-result.json` reported `verdict=passed`, `scenario_count=34`, `failed=[]`.

## Review

Fresh critic pass returned `NO BLOCKING GAPS`. Earlier critic blockers were addressed: schema compatibility, public-note filtering, full JSON contract replay assertions, and Enterprise feed URLs.

Agent: codex
Agent-Surface: Codex CLI
Agent-Model: GPT-5.5
Agent-Task: landmark-902
