### PR TITLE
[codex] Add gated social draft release-kit artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,8 +395,12 @@ upgrade the bump, a provider skip or failure is recorded without silently
 changing the floor, and a commit/API disagreement records a typed waiver need
 instead of hiding the conflict. `--dry-run` keeps the filesystem untouched and
 prints the same `release_kit` object inside the stdout evidence packet. Low internal
-releases keep the kit to Landmark-owned changelog and notes evidence;
-high-importance, security, breaking, or migration-heavy releases add planned
+releases keep the kit to Landmark-owned changelog and notes evidence. Eligible
+non-patch release moments also embed gated social post drafts in the kit: two
+short variants, an angle note, the release evidence link, and the configured
+voice card. Those drafts are Landmark-owned text artifacts, but their approval
+state stays pending for operator review and Landmark has no autopost path.
+High-importance, security, breaking, or migration-heavy releases add planned
 producer-adapter artifacts such as migration guides, docs updates, blog drafts,
 and demo videos with explicit handoff contracts, evidence paths, and pending
 approval state.

--- a/crates/landmark/src/release_kit.rs
+++ b/crates/landmark/src/release_kit.rs
@@ -2,7 +2,7 @@ use super::{
     ContextCommit, DeterministicReleaseContext, LandmarkManifest, RunArgs, RunArtifactRecord,
     RunPublicationRecord, RunReleaseContext, RunVersionDecision,
     classify_release_context_with_deterministic, context_changed_files, context_source,
-    conventional_commit_type, is_breaking_commit, sha256_hex, trimmed_option,
+    conventional_commit_type, is_breaking_commit, sanitize_text, sha256_hex, trimmed_option,
 };
 use serde::Serialize;
 use std::collections::BTreeSet;
@@ -10,6 +10,10 @@ use std::path::PathBuf;
 
 pub(crate) const SCHEMA_VERSION: &str = "landmark.release-kit.v1";
 const PRODUCER_EVIDENCE_DIR: &str = ".landmark/run/producers";
+const SOCIAL_DRAFT_ARTIFACT_ID: &str = "social-post-drafts";
+const SOCIAL_POST_LIMIT: usize = 280;
+const DEFAULT_SOCIAL_VOICE_CARD: &str =
+    "clear, specific, user-facing release voice grounded in release evidence";
 
 #[derive(Clone, Debug, Serialize)]
 pub(super) struct ReleaseKit {
@@ -68,6 +72,16 @@ struct ReleaseKitArtifact {
     blocker: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     waiver: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    draft: Option<ReleaseKitSocialDraft>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ReleaseKitSocialDraft {
+    voice_card: String,
+    variants: Vec<String>,
+    angle: String,
+    evidence_link: String,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -130,6 +144,19 @@ struct ReleaseKitArtifactSpec<'a> {
     sha256: Option<String>,
     acceptance: &'a [&'a str],
     depends_on: &'a [&'a str],
+}
+
+struct SocialDraftInput<'a> {
+    dry_run: bool,
+    primary_audience: &'a str,
+    product_name: &'a str,
+    version: &'a str,
+    release_tag: &'a str,
+    release_url: &'a str,
+    notes: &'a str,
+    classification: &'a super::ReleaseClassification,
+    decision: &'a RunVersionDecision,
+    voice: Option<&'a str>,
 }
 
 pub(super) fn schema_version() -> &'static str {
@@ -215,6 +242,11 @@ pub(super) fn plan(input: PlanInput<'_>) -> ReleaseKit {
     let feed_status = artifact_status(args.dry_run, &artifacts.rss);
     let technical_sha = sha256_hex(technical_changelog.as_bytes());
     let notes_sha = sha256_hex(notes.as_bytes());
+    let social_draft_eligible = release_kit_social_draft_eligible(
+        &release_classification,
+        &release.decision,
+        technical_changelog,
+    );
 
     let mut kit_artifacts = vec![
         release_kit_artifact(ReleaseKitArtifactSpec {
@@ -262,6 +294,20 @@ pub(super) fn plan(input: PlanInput<'_>) -> ReleaseKit {
             depends_on: &["release-notes"],
         }));
     }
+    if social_draft_eligible {
+        kit_artifacts.push(social_post_draft_artifact(SocialDraftInput {
+            dry_run: args.dry_run,
+            primary_audience: &primary_audience,
+            product_name: &product_name,
+            version: &release.version,
+            release_tag: &release.release_tag,
+            release_url: &publication.release_url,
+            notes,
+            classification: &release_classification,
+            decision: &release.decision,
+            voice: manifest.voice.as_deref(),
+        }));
+    }
 
     let rich_artifacts = release_kit_needs_rich_artifacts(&importance);
     if rich_artifacts {
@@ -299,7 +345,17 @@ pub(super) fn plan(input: PlanInput<'_>) -> ReleaseKit {
     let approvals = kit_artifacts
         .iter()
         .map(|artifact| {
-            if artifact.owner == "producer-adapter" {
+            if artifact.id == SOCIAL_DRAFT_ARTIFACT_ID {
+                ReleaseKitApproval {
+                    artifact_id: artifact.id.clone(),
+                    state: "pending".into(),
+                    approver: None,
+                    reason: Some(
+                        "operator review queue: social drafts are gated and Landmark has no autopost path"
+                            .into(),
+                    ),
+                }
+            } else if artifact.owner == "producer-adapter" {
                 ReleaseKitApproval {
                     artifact_id: artifact.id.clone(),
                     state: "pending".into(),
@@ -328,9 +384,7 @@ pub(super) fn plan(input: PlanInput<'_>) -> ReleaseKit {
     let status_summary = if args.dry_run {
         "dry-run release kit printed in evidence; no artifacts were written".to_string()
     } else if pending_approvals > 0 {
-        format!(
-            "release kit generated with {pending_approvals} producer-owned artifact approvals pending"
-        )
+        format!("release kit generated with {pending_approvals} artifact approvals pending")
     } else if complete {
         "release kit complete for Landmark-owned outputs".into()
     } else {
@@ -447,6 +501,153 @@ fn rich_release_artifacts(primary_audience: &str, release_tag: &str) -> Vec<Rele
     ]
 }
 
+fn social_post_draft_artifact(input: SocialDraftInput<'_>) -> ReleaseKitArtifact {
+    let note = primary_social_note(input.notes);
+    let angle = social_post_angle(input.classification, input.decision);
+    let evidence_link = social_evidence_link(input.release_url, input.release_tag);
+    let voice_card = input
+        .voice
+        .and_then(trimmed_option)
+        .unwrap_or_else(|| DEFAULT_SOCIAL_VOICE_CARD.into());
+    let voice_label = social_voice_label(&voice_card);
+    let variants = vec![
+        social_post_variant(
+            &voice_label,
+            &format!("{} {}", input.product_name, input.version),
+            &note,
+            &evidence_link,
+        ),
+        social_post_variant(
+            &voice_label,
+            &format!("{} {}: {angle}", input.product_name, input.release_tag),
+            &note,
+            &evidence_link,
+        ),
+    ];
+    let mut artifact = release_kit_artifact(ReleaseKitArtifactSpec {
+        id: SOCIAL_DRAFT_ARTIFACT_ID,
+        kind: "social_copy",
+        audience: input.primary_audience,
+        owner: "landmark",
+        status: if input.dry_run { "planned" } else { "produced" },
+        path: None,
+        sha256: None,
+        acceptance: &[
+            "Contains exactly two short-post variants, one angle note, and the release evidence link.",
+            "Applies the configured voice card without inventing release claims.",
+            "Remains draft-only with pending operator review; Landmark provides no autopost path.",
+        ],
+        depends_on: &["release-notes"],
+    });
+    artifact.blocker = Some("pending operator review; draft must not be autoposted".into());
+    artifact.draft = Some(ReleaseKitSocialDraft {
+        voice_card,
+        variants,
+        angle,
+        evidence_link,
+    });
+    artifact
+}
+
+pub(crate) fn release_kit_social_draft_eligible(
+    classification: &super::ReleaseClassification,
+    decision: &RunVersionDecision,
+    technical_changelog: &str,
+) -> bool {
+    if matches!(decision.bump.as_str(), "none" | "patch") {
+        return false;
+    }
+    let signals = &classification.deterministic_signals;
+    let breaking = classification.breaking || decision.bump == "major";
+    let capability =
+        decision.bump == "minor" && signals.iter().any(|signal| signal == "conventional:feat");
+    let proof_backed_perf = signals.iter().any(|signal| signal == "conventional:perf")
+        && has_crucible_receipt(technical_changelog);
+    breaking || capability || proof_backed_perf
+}
+
+fn has_crucible_receipt(technical_changelog: &str) -> bool {
+    let lower = technical_changelog.to_ascii_lowercase();
+    lower.contains("crucible") && lower.contains("receipt")
+}
+
+fn primary_social_note(notes: &str) -> String {
+    for line in notes.lines() {
+        let trimmed = line.trim();
+        if let Some(bullet) = trimmed.strip_prefix("- ") {
+            return sanitize_text(bullet.trim());
+        }
+    }
+    notes
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty() && !line.starts_with('#'))
+        .map(sanitize_text)
+        .unwrap_or_else(|| "Release notes are ready for operator review".into())
+}
+
+fn social_post_angle(
+    classification: &super::ReleaseClassification,
+    decision: &RunVersionDecision,
+) -> String {
+    if classification.breaking || decision.bump == "major" {
+        "the interesting bit is the upgrade moment and what operators need to notice".into()
+    } else if classification
+        .deterministic_signals
+        .iter()
+        .any(|signal| signal == "conventional:perf")
+    {
+        "the interesting bit is the proof-backed performance change".into()
+    } else {
+        "the interesting bit is the new user-facing capability".into()
+    }
+}
+
+fn social_evidence_link(release_url: &str, release_tag: &str) -> String {
+    trimmed_option(release_url).unwrap_or_else(|| format!("release-kit:{release_tag}"))
+}
+
+pub(crate) fn social_voice_label(voice_card: &str) -> String {
+    let lower = voice_card.to_ascii_lowercase();
+    if lower.contains("operator") {
+        "Operator note".into()
+    } else if lower.contains("developer") || lower.contains("maintainer") {
+        "Maintainer note".into()
+    } else if lower.contains("user") || lower.contains("public") {
+        "User-facing note".into()
+    } else {
+        "Release note".into()
+    }
+}
+
+fn social_post_variant(voice_label: &str, prefix: &str, note: &str, evidence_link: &str) -> String {
+    let suffix = format!(" Evidence: {evidence_link}");
+    let voice_label = sanitize_text(voice_label);
+    let prefix = sanitize_text(prefix);
+    let reserved =
+        voice_label.chars().count() + prefix.chars().count() + suffix.chars().count() + 4;
+    let note_limit = SOCIAL_POST_LIMIT.saturating_sub(reserved);
+    let note = truncate_for_social(note, note_limit);
+    sanitize_text(&format!("{voice_label}: {prefix}: {note}.{suffix}"))
+}
+
+fn truncate_for_social(text: &str, max_chars: usize) -> String {
+    let clean = sanitize_text(text);
+    if clean.chars().count() <= max_chars {
+        clean
+    } else if max_chars <= 3 {
+        clean.chars().take(max_chars).collect()
+    } else {
+        let truncated = clean
+            .chars()
+            .take(max_chars - 3)
+            .collect::<String>()
+            .trim_end()
+            .to_string();
+        format!("{truncated}...")
+    }
+}
+
 fn artifact_status(dry_run: bool, path: &str) -> String {
     if dry_run || path.trim().is_empty() {
         "planned".into()
@@ -526,6 +727,7 @@ fn release_kit_artifact(spec: ReleaseKitArtifactSpec<'_>) -> ReleaseKitArtifact 
         depends_on: spec.depends_on.iter().map(|item| (*item).into()).collect(),
         blocker: None,
         waiver: None,
+        draft: None,
     }
 }
 

--- a/crates/landmark/src/release_kit_contract.rs
+++ b/crates/landmark/src/release_kit_contract.rs
@@ -79,6 +79,9 @@ pub(crate) fn assert_contract(value: &Value, label: &str) -> Result<()> {
         {
             return Err(format!("{label} artifact missing acceptance checks").into());
         }
+        if artifact["id"] == "social-post-drafts" {
+            assert_social_draft_artifact(artifact, label)?;
+        }
     }
     for provenance in value["provenance"]
         .as_array()
@@ -110,6 +113,19 @@ pub(crate) fn assert_contract(value: &Value, label: &str) -> Result<()> {
         if approval["state"].as_str().unwrap_or_default().is_empty() {
             return Err(format!("{label} approval missing state").into());
         }
+    }
+    if artifacts
+        .iter()
+        .any(|artifact| artifact["id"] == "social-post-drafts")
+        && !value["approvals"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|approval| {
+                approval["artifact_id"] == "social-post-drafts" && approval["state"] == "pending"
+            })
+    {
+        return Err(format!("{label} social draft artifact is not pending operator review").into());
     }
     for contract in value["producer_contracts"]
         .as_array()
@@ -164,6 +180,51 @@ pub(crate) fn assert_contract(value: &Value, label: &str) -> Result<()> {
                     .into());
                 }
             }
+        }
+    }
+    Ok(())
+}
+
+fn assert_social_draft_artifact(artifact: &Value, label: &str) -> Result<()> {
+    if artifact["kind"] != "social_copy" {
+        return Err(format!("{label} social draft artifact must be social_copy").into());
+    }
+    if artifact["owner"] != "landmark" {
+        return Err(format!("{label} social draft artifact must be Landmark-owned").into());
+    }
+    let blocker = artifact["blocker"].as_str().unwrap_or_default();
+    if !blocker.contains("autopost") {
+        return Err(format!("{label} social draft artifact must keep autopost blocked").into());
+    }
+    let draft = artifact
+        .get("draft")
+        .ok_or_else(|| format!("{label} social draft artifact missing draft payload"))?;
+    for pointer in ["/voice_card", "/angle", "/evidence_link"] {
+        if draft
+            .pointer(pointer)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+        {
+            return Err(format!("{label} social draft missing string at {pointer}").into());
+        }
+    }
+    let variants = draft["variants"]
+        .as_array()
+        .ok_or_else(|| format!("{label} social draft variants must be an array"))?;
+    if variants.len() != 2 {
+        return Err(format!("{label} social draft must include exactly two variants").into());
+    }
+    for variant in variants {
+        let variant = variant
+            .as_str()
+            .ok_or_else(|| format!("{label} social draft variant must be a string"))?;
+        if variant.trim().is_empty() {
+            return Err(format!("{label} social draft variant is empty").into());
+        }
+        if variant.chars().count() > 280 {
+            return Err(format!("{label} social draft variant exceeds 280 characters").into());
         }
     }
     Ok(())

--- a/crates/landmark/src/release_kit_tests.rs
+++ b/crates/landmark/src/release_kit_tests.rs
@@ -1,5 +1,6 @@
 use super::release_kit::{
     release_kit_audiences, release_kit_importance, release_kit_needs_rich_artifacts,
+    release_kit_social_draft_eligible, social_voice_label,
 };
 use super::*;
 
@@ -184,4 +185,76 @@ fn audiences_add_release_operator_and_docs_owner_only_when_rich_artifacts_needed
             "{importance} should not add docs-owner"
         );
     }
+}
+
+#[test]
+fn social_draft_gate_excludes_chore_and_patch_noise() {
+    let mut chore = baseline_classification();
+    chore.user_visible = false;
+    chore.significance = "low".into();
+    chore.categories = vec!["chore-only".into()];
+    chore.deterministic_signals = vec!["conventional:chore".into()];
+    let patch_decision = RunVersionDecision {
+        bump: "patch".into(),
+        commit_bump: "patch".into(),
+        ..baseline_decision()
+    };
+    assert!(!release_kit_social_draft_eligible(
+        &chore,
+        &patch_decision,
+        "## Technical\n\n- chore(ci): refresh workflow"
+    ));
+
+    let mut fix = baseline_classification();
+    fix.deterministic_signals = vec!["conventional:fix".into()];
+    assert!(!release_kit_social_draft_eligible(
+        &fix,
+        &patch_decision,
+        "## Technical\n\n- fix(cli): handle empty config"
+    ));
+
+    let mut perf = baseline_classification();
+    perf.deterministic_signals = vec!["conventional:perf".into()];
+    assert!(!release_kit_social_draft_eligible(
+        &perf,
+        &patch_decision,
+        "## Technical\n\n- perf(api): reduce feed latency\n\nCrucible receipt: https://example.invalid/receipts/perf"
+    ));
+}
+
+#[test]
+fn social_draft_gate_allows_capabilities_and_breaking_changes() {
+    let mut capability = baseline_classification();
+    capability.deterministic_signals = vec!["conventional:feat".into()];
+    assert!(release_kit_social_draft_eligible(
+        &capability,
+        &baseline_decision(),
+        "## Technical\n\n- feat(cli): add release preview"
+    ));
+
+    let mut breaking = baseline_classification();
+    breaking.breaking = true;
+    assert!(release_kit_social_draft_eligible(
+        &breaking,
+        &RunVersionDecision {
+            bump: "major".into(),
+            commit_bump: "major".into(),
+            ..baseline_decision()
+        },
+        "## Technical\n\n- feat(api)!: rename release field"
+    ));
+}
+
+#[test]
+fn social_voice_card_changes_draft_label() {
+    assert_eq!(
+        social_voice_label("operator-facing, concrete, low-hype"),
+        "Operator note"
+    );
+    assert_eq!(
+        social_voice_label("developer and maintainer focused"),
+        "Maintainer note"
+    );
+    assert_eq!(social_voice_label("public user-facing"), "User-facing note");
+    assert_eq!(social_voice_label("plain and quiet"), "Release note");
 }

--- a/crates/landmark/src/replay/mod.rs
+++ b/crates/landmark/src/replay/mod.rs
@@ -138,6 +138,10 @@ pub(crate) fn scenario_map() -> BTreeMap<String, Scenario> {
         scenario_local_provider_run,
     );
     map.insert(
+        "misty_step_landmark_social_draft".to_string(),
+        scenario_misty_step_landmark_social_draft,
+    );
+    map.insert(
         "release_kit_classification_uses_structured_commits".to_string(),
         scenario_release_kit_classification_uses_structured_commits,
     );
@@ -255,6 +259,7 @@ pub(crate) fn canonical_scenarios() -> Vec<&'static str> {
         "first_run_local_preview",
         "github_provider_run",
         "local_provider_run",
+        "misty_step_landmark_social_draft",
         "release_kit_classification_uses_structured_commits",
         "release_grounding_unified_path",
         "semver_evidence_agrees",

--- a/crates/landmark/src/replay/provider_scenarios/provider_runs.rs
+++ b/crates/landmark/src/replay/provider_scenarios/provider_runs.rs
@@ -167,6 +167,60 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
             "local run evidence release kit did not match written release-kit artifact".into(),
         );
     }
+    let social_draft = release_kit_artifact(&release_kit_file, "social-post-drafts")
+        .ok_or("local run did not emit social-post-drafts for a feature release")?;
+    let social_draft_payload = &social_draft["draft"];
+    if social_draft["kind"] != "social_copy"
+        || social_draft["status"] != "produced"
+        || social_draft_payload["variants"]
+            .as_array()
+            .is_none_or(|variants| variants.len() != 2)
+        || social_draft_payload["angle"]
+            .as_str()
+            .is_none_or(|angle| !angle.contains("user-facing capability"))
+        || social_draft_payload["voice_card"]
+            .as_str()
+            .is_none_or(|voice_card| voice_card.trim().is_empty())
+        || social_draft_payload["evidence_link"] != "local://local-provider-run/releases/v1.1.0"
+    {
+        return Err(format!(
+            "local run social draft did not include two variants, angle, and evidence link: {social_draft}"
+        )
+        .into());
+    }
+    if !release_kit_file["approvals"]
+        .as_array()
+        .is_some_and(|approvals| {
+            approvals.iter().any(|approval| {
+                approval["artifact_id"] == "social-post-drafts" && approval["state"] == "pending"
+            })
+        })
+    {
+        return Err("local run social draft was not gated behind pending operator review".into());
+    }
+    if release_kit_file["producer_contracts"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|contract| {
+            contract["output_artifacts"]
+                .as_array()
+                .into_iter()
+                .flatten()
+        })
+        .any(|artifact| artifact == "social-post-drafts")
+    {
+        return Err("local run social draft unexpectedly had a producer/autopost contract".into());
+    }
+    let social_text = serde_json::to_string(social_draft_payload)?;
+    for leaked in ["feat(", "chore(ci)", "agent lane", "autopost"] {
+        if social_text.contains(leaked) {
+            return Err(format!(
+                "local run social draft leaked internal or publication detail `{leaked}`: {social_text}"
+            )
+            .into());
+        }
+    }
     let notes = fs::read_to_string(&markdown)?;
     if !notes.contains("Add portable release run") {
         return Err("local run release notes did not include the feature commit".into());
@@ -416,6 +470,7 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
         || internal_artifacts
             .iter()
             .any(|artifact| artifact["owner"] == "producer-adapter")
+        || release_kit_artifact(&internal_evidence["release_kit"], "social-post-drafts").is_some()
     {
         return Err("low-importance internal release kit did not stay small".into());
     }
@@ -436,6 +491,13 @@ pub(crate) fn scenario_local_provider_run(tmp_root: &Path) -> Result<Value> {
             "release_kit": release_kit,
         }
     }))
+}
+
+fn release_kit_artifact<'a>(release_kit: &'a Value, id: &str) -> Option<&'a Value> {
+    release_kit["artifacts"]
+        .as_array()?
+        .iter()
+        .find(|artifact| artifact["id"] == id)
 }
 
 pub(crate) fn assert_public_release_entry_contract(entry: &Value) -> Result<()> {
@@ -819,5 +881,74 @@ pub(crate) fn scenario_release_kit_classification_uses_structured_commits(
     Ok(json!({
         "evidence": evidence,
         "classification": classification,
+    }))
+}
+
+pub(crate) fn scenario_misty_step_landmark_social_draft(_: &Path) -> Result<Value> {
+    let repo = env::current_dir()?;
+    let result = Command::new(current_exe())
+        .args([
+            "run",
+            "--provider",
+            "local",
+            "--repo-root",
+            repo.to_str().unwrap_or("."),
+            "--repository",
+            "misty-step/landmark",
+            "--release-tag",
+            "v1.27.0",
+            "--dry-run",
+        ])
+        .output()?;
+    if !result.status.success() {
+        return Err(String::from_utf8_lossy(&result.stderr).to_string().into());
+    }
+    let evidence: Value = serde_json::from_slice(&result.stdout)?;
+    if evidence["release_tag"] != "v1.27.0" || evidence["version_decision"]["bump"] != "minor" {
+        return Err("real Landmark release proof did not exercise v1.27.0 minor release".into());
+    }
+    release_kit_contract::assert_contract(&evidence["release_kit"], "real Landmark release kit")?;
+    let social = release_kit_artifact(&evidence["release_kit"], "social-post-drafts")
+        .ok_or("real Landmark release did not emit social-post-drafts")?;
+    let draft = &social["draft"];
+    if social["status"] != "planned"
+        || social["kind"] != "social_copy"
+        || draft["variants"]
+            .as_array()
+            .is_none_or(|variants| variants.len() != 2)
+        || draft["voice_card"]
+            .as_str()
+            .is_none_or(|voice_card| voice_card.trim().is_empty())
+        || draft["evidence_link"] != "https://github.com/misty-step/landmark/releases/tag/v1.27.0"
+    {
+        return Err(
+            format!("real Landmark release social draft missing draft shape: {social}").into(),
+        );
+    }
+    let variants = draft["variants"].as_array().unwrap();
+    if !variants
+        .iter()
+        .filter_map(Value::as_str)
+        .all(|variant| variant.starts_with("User-facing note:"))
+    {
+        return Err(format!(
+            "real Landmark release social variants did not apply the voice label: {variants:?}"
+        )
+        .into());
+    }
+    if !evidence["release_kit"]["approvals"]
+        .as_array()
+        .is_some_and(|approvals| {
+            approvals.iter().any(|approval| {
+                approval["artifact_id"] == "social-post-drafts" && approval["state"] == "pending"
+            })
+        })
+    {
+        return Err("real Landmark release social draft was not pending operator review".into());
+    }
+    Ok(json!({
+        "release_tag": evidence["release_tag"],
+        "version_decision": evidence["version_decision"],
+        "social": social,
     }))
 }

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -120,6 +120,11 @@ Typical release-kit artifacts include migration guides, docs patches, blog
 drafts, essays, announcement copy, social copy, screenshots, images, GIFs, demo
 scripts, and demo videos. Text artifacts may be produced directly by Landmark;
 rich media and publication-specific outputs should stay adapter-owned.
+When a release passes the deterministic social-draft gate, the kit embeds
+`social-post-drafts` as draft-only `social_copy`: two short variants, an angle
+note, the release evidence link, and the configured voice card. Its approval
+state remains `pending`; downstream systems may route it to an operator review
+queue, but Landmark does not publish or autopost it.
 
 ## Glossary
 

--- a/schemas/release-kit.v1.schema.json
+++ b/schemas/release-kit.v1.schema.json
@@ -97,7 +97,18 @@
           "acceptance": { "type": "array", "items": { "type": "string" } },
           "depends_on": { "type": "array", "items": { "type": "string" } },
           "blocker": { "type": "string" },
-          "waiver": { "type": "string" }
+          "waiver": { "type": "string" },
+          "draft": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["voice_card", "variants", "angle", "evidence_link"],
+            "properties": {
+              "voice_card": { "type": "string" },
+              "variants": { "type": "array", "items": { "type": "string" } },
+              "angle": { "type": "string" },
+              "evidence_link": { "type": "string" }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds the gated social-post draft artifact requested by `landmark-903` to the release kit.

- emits `social-post-drafts` as draft-only `social_copy` for eligible non-patch release moments
- includes exactly two variants, one angle note, the release evidence link, and the applied voice card
- keeps the approval state pending for operator review and provides no autopost producer contract
- extends the release-kit schema/docs and replay coverage, including a real `misty-step/landmark` `v1.27.0` proof

## Verification

- `cargo test --locked -p landmark release_kit_tests`
- `cargo run --locked -p landmark -- replay-action --scenario local_provider_run --scenario misty_step_landmark_social_draft --evidence-dir /tmp/landmark-903-replay`
- `bin/gate`
  - architecture ratchet ok
  - 100 Rust tests passed
  - `check-version-sync --reference origin/master`: metadata matches latest tag version 1.27.0
  - `check-action-contract`: action contract ok
  - replay evidence: `.landmark/replay/replay-result.json`, `verdict=passed`, `scenario_count=35`, `failed=[]`
  - non-Linux host skipped musl build check; release workflow matrix owns that build

## Review

Fresh read-only critic result: `NO BLOCKING GAPS`.

## Agent Attribution

Agent: codex-implementation-lane  
Agent-Surface: Codex CLI  
Agent-Model: GPT-5.5  
Agent-Task: landmark-903
