### PR TITLE
fix(ci): release with an org GitHub App token instead of the expired PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,22 @@ jobs:
             --release-branch landmark/self-release \
             --github-output "${GITHUB_OUTPUT}"
 
+      # An org-owned GitHub App token instead of a user PAT: PRs it creates
+      # still trigger pull_request workflows (required merge-gate), and it
+      # carries no personal-account expiry. See Powder landmark-016/017.
+      - name: Mint release-bot token
+        if: steps.prepare.outputs.released == 'true'
+        id: bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Open or update release pull request
         if: steps.prepare.outputs.released == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GH_RELEASE_TOKEN }}
+          token: ${{ steps.bot-token.outputs.token }}
           branch: ${{ steps.prepare.outputs.release_branch }}
           delete-branch: true
           title: ${{ steps.prepare.outputs.pull_request_title }}
@@ -70,11 +81,18 @@ jobs:
       published: ${{ steps.publish.outputs.published }}
       release_tag: ${{ steps.publish.outputs.release_tag }}
     steps:
+      - name: Mint release-bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Checkout landed release
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_RELEASE_TOKEN }}
+          token: ${{ steps.bot-token.outputs.token }}
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -85,12 +103,12 @@ jobs:
         id: publish
         shell: bash
         env:
-          GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          RELEASE_BOT_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
           set -euo pipefail
           cargo run --locked -p landmark -- publish-self-release \
             --repo-root . \
-            --github-token "${GH_RELEASE_TOKEN}" \
+            --github-token "${RELEASE_BOT_TOKEN}" \
             --repository "${GITHUB_REPOSITORY}" \
             --target-sha "${GITHUB_SHA}" \
             --github-output "${GITHUB_OUTPUT}"
@@ -178,11 +196,18 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Mint release-bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Checkout landed release
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_RELEASE_TOKEN }}
+          token: ${{ steps.bot-token.outputs.token }}
 
       - name: Download release assets
         uses: actions/download-artifact@v4
@@ -199,7 +224,7 @@ jobs:
       - name: Upload release assets
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          GH_TOKEN: ${{ steps.bot-token.outputs.token }}
         run: |
           set -euo pipefail
           gh release upload "${{ needs.publish-landed-release.outputs.release_tag }}" \
@@ -214,7 +239,7 @@ jobs:
         with:
           mode: synthesis-only
           release-tag: ${{ needs.publish-landed-release.outputs.release_tag }}
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ steps.bot-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           synthesis-required: "false"
           floating-tags: "true"


### PR DESCRIPTION
## What

Replaces every `secrets.GH_RELEASE_TOKEN` reference in the Release workflow with short-lived installation tokens minted from the org-owned **misty-step-release-bot** GitHub App (`actions/create-github-app-token@v2`, org secrets `RELEASE_BOT_APP_ID` + `RELEASE_BOT_PRIVATE_KEY`).

## Why

The org secret held a user PAT that expired 2026-07-04 — every Release run since fails with a git 403 pushing `landmark/self-release` (last good release v1.27.0, Jul 2; stale release PR #194 frozen since Jul 4). The workflow's own `GITHUB_TOKEN` cannot substitute: PRs it creates don't trigger `pull_request` workflows, and `merge-gate` is a required check on protected master with `enforce_admins` on.

An org App is the durable fix: no personal-account coupling, no expiry clock, App-created PRs trigger CI, App-created releases emit `release: published`, 1-hour runtime tokens, key rotatable without workflow edits.

## Deployment note

Merging is safe before the App secrets exist (CI doesn't exercise this workflow); the Release workflow simply keeps failing until `RELEASE_BOT_APP_ID`/`RELEASE_BOT_PRIVATE_KEY` are set at the org level — being provisioned in parallel. After both land: dispatch Release → release PR #194 refreshes with working auth → merge-gate fires → v1.28.0 ships with binaries.

Part of the fleet release-auth redesign (Powder landmark-016/landmark-017): consumers move to `github.token` during the @v0 re-pin sweep; `GH_RELEASE_TOKEN` retires entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)