### PR TITLE
chore(release): reset version line to 0.28.0 (pre-stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Version reset: 1.28.0 → 0.28.0 (2026-07-08)
+
+The fleet moved to pre-stable 0.x semantics (landmark-016). The 1.x line was
+renumbered to 0.x with the same content: v1.28.0 == v0.28.0 (commit
+80ce543). Pre-1.0 bumps follow Cargo-style semver — breaking changes bump
+the minor version, features and fixes bump the patch version. `1.0.0` will
+only ever be tagged deliberately, once the API is ready to commit to
+stability.
+
 # [1.28.0](https://github.com/misty-step/landmark/compare/v1.27.0...v1.28.0) (2026-07-08)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "landmark"
-version = "1.28.0"
+version = "0.28.0"
 dependencies = [
  "chrono",
  "clap",

--- a/crates/landmark/Cargo.toml
+++ b/crates/landmark/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "landmark"
-version = "1.28.0"
+version = "0.28.0"
 edition = "2024"
 description = "Portable release-intelligence runtime for repositories using conventional commits"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
   "license": "MIT",
   "name": "landmark",
   "private": true,
-  "version": "1.28.0"
+  "version": "0.28.0"
 }


### PR DESCRIPTION
## Summary

Resets landmark's version metadata from `1.28.0` to `0.28.0`, completing the self-application of the pre-stable 0.x semantics landed in landmark-016 (#204).

- `package.json`: `1.28.0` → `0.28.0`
- `crates/landmark/Cargo.toml`: `1.28.0` → `0.28.0`
- `Cargo.lock`: `landmark` package entry updated to match
- `CHANGELOG.md`: prepended a reset note explaining the renumbering and the new Cargo-style pre-1.0 bump semantics

`crates/landmark-mcp/Cargo.toml` carries its own independent version (`0.1.0`) and does not pin the `landmark` crate version, so it needs no change.

This is part of Powder card **landmark-017** (fleet-wide version-metadata reset from the 1.x line to 0.x).

## Tag continuity

`v0.28.0` and `v0` already exist and point at the same commit as `v1.28.0` (`80ce543`), so `v1.28.0 == v0.28.0` in content. This PR just brings the in-repo metadata in line with that tag state.

## Expected CI state

**This PR's `check-version-sync` gate will open RED.** That check requires `package.json`'s version to equal the highest *merged* tag, which is still `v1.28.0` until the legacy `v1.x` tags are deleted. The lead will delete the `v1.x` tags immediately after this PR opens and re-run CI, at which point the gate goes green against the `v0.x` tag line. This is expected choreography, not a bug in this PR — no code change here should attempt to "fix" the red gate.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo metadata --no-deps` — parses without error
- [x] `cargo build --locked` — succeeds, compiles `landmark v0.28.0`
- [x] `cargo test --locked` — 113 passed (landmark) + 5 passed (landmark-mcp), 0 failed
- [ ] CI `check-version-sync` — expected RED until v1.x tags are deleted (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version from `1.28.0` to `0.28.0` across release metadata.
  * Added a changelog note explaining the version reset and the new pre-stable versioning approach.
  * Clarified that future pre-1.0 updates will follow Cargo-style semantics, with `1.0.0` reserved for a deliberate stability commitment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->