### PR TITLE
fix(fleet): generate and document landmark@v0 + workflow-token releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,9 +135,9 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional:
           # llm-model: anthropic/claude-sonnet-4
@@ -147,7 +147,10 @@ jobs:
 ## Requirements
 - Node.js 22+
 - Rust stable
-- `GH_RELEASE_TOKEN` secret (PAT with repo write + admin bypass)
+- The workflow-level `permissions: { contents: write, issues: write, pull-requests: write }`
+  block above — the default `${{ github.token }}` covers landmark's own action
+  invocation; a PAT is only needed if downstream automation must trigger further
+  workflow runs.
 - `OPENROUTER_API_KEY` secret (or another compatible provider API key)
 
 ## Backlog And Docs

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ jobs:
       # Landmark: Automated semantic-release pipeline
       # https://github.com/misty-step/landmark
       - name: Run Landmark
-        uses: misty-step/landmark@v1
+        uses: misty-step/landmark@v0
         with:
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional: customize model and fallbacks
           # llm-model: anthropic/claude-sonnet-5
@@ -199,11 +199,11 @@ Use synthesis-only when release-please, Changesets, manual GitHub Releases, or a
 custom pipeline already creates the version and release:
 
 ```yaml
-- uses: misty-step/landmark@v1
+- uses: misty-step/landmark@v0
   with:
     mode: synthesis-only
     release-tag: ${{ steps.release.outputs.tag_name }}
-    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    github-token: ${{ github.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
 
@@ -292,9 +292,9 @@ permissions, package topology, recent conventional-commit usage, and any
 checked-in `.landmark.yml`. It prints a JSON report with a recommended Landmark
 mode and writes workflow candidates for semantic-release, release-please,
 changesets, changesets monorepos, and manual-tag repositories. Every generated
-workflow includes `healthcheck: 'true'`, `GH_RELEASE_TOKEN`,
-`OPENROUTER_API_KEY`, and the `contents`, `issues`, and `pull-requests`
-permissions Landmark needs.
+workflow includes `healthcheck: 'true'`, the default `GITHUB_TOKEN` (via
+`github-token: ${{ github.token }}`), `OPENROUTER_API_KEY`, and the
+`contents`, `issues`, and `pull-requests` permissions Landmark needs.
 
 ## Fleet Adoption
 
@@ -571,18 +571,18 @@ distribution steps:
 ### OpenRouter (default)
 
 ```yaml
-- uses: misty-step/landmark@v1
+- uses: misty-step/landmark@v0
   with:
-    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    github-token: ${{ github.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
 
 ### OpenAI
 
 ```yaml
-- uses: misty-step/landmark@v1
+- uses: misty-step/landmark@v0
   with:
-    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    github-token: ${{ github.token }}
     llm-api-key: ${{ secrets.OPENAI_API_KEY }}
     llm-model: gpt-4o
     llm-api-url: https://api.openai.com/v1/chat/completions
@@ -591,9 +591,9 @@ distribution steps:
 ### Custom OpenAI-Compatible Provider
 
 ```yaml
-- uses: misty-step/landmark@v1
+- uses: misty-step/landmark@v0
   with:
-    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    github-token: ${{ github.token }}
     llm-api-key: ${{ secrets.PROVIDER_API_KEY }}
     llm-model: provider/model-id
     llm-api-url: https://provider.example.com/v1/chat/completions
@@ -641,9 +641,9 @@ For private repos where GitHub Releases aren't publicly visible, use artifact ou
 ```yaml
 - name: Run Landmark
   id: landmark
-  uses: misty-step/landmark@v1
+  uses: misty-step/landmark@v0
   with:
-    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    github-token: ${{ github.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
     notes-output-file: docs/releases/{version}.md
     notes-output-text-file: docs/releases/{version}.txt
@@ -780,9 +780,9 @@ The `synthesis-status` output is a compact JSON object for automation:
 To publish a simple RSS 2.0 release feed (for feed readers, docs sites, etc.), set `rss-feed-file`:
 
 ```yaml
-- uses: misty-step/landmark@v1
+- uses: misty-step/landmark@v0
   with:
-    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    github-token: ${{ github.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
     rss-feed-file: docs/releases.xml
     rss-max-entries: "50"

--- a/SKILL.md
+++ b/SKILL.md
@@ -25,7 +25,7 @@ agent-native contracts, or release-kit producer responsibilities.
 | Dry-run release analysis | `landmark run --provider local --dry-run` |
 | Install in a repo | `landmark setup` |
 | Fleet adoption | `fleet scan`, `fleet plan`, `fleet open-prs` |
-| GitHub Action use | `misty-step/landmark@v1` |
+| GitHub Action use | `misty-step/landmark@v0` |
 | Local development | `cargo run --locked -p landmark -- ...` |
 | Query core verbs over MCP | `cargo run --locked -p landmark-mcp` (stdio) |
 | Full repo gate | `bin/gate` |

--- a/crates/landmark/src/setup_fleet/diagnose.rs
+++ b/crates/landmark/src/setup_fleet/diagnose.rs
@@ -282,11 +282,11 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: full
           healthcheck: 'true'
-          github-token: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+          github-token: ${{{{ github.token }}}}
           llm-api-key: ${{{{ secrets.OPENROUTER_API_KEY }}}}
 {manifest_inputs}
 "#
@@ -333,12 +333,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           healthcheck: 'true'
           release-tag: ${{{{ needs.{release_job}.outputs.tag_name }}}}
-          github-token: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+          github-token: ${{{{ github.token }}}}
           llm-api-key: ${{{{ secrets.OPENROUTER_API_KEY }}}}
 {manifest_inputs}
 "#
@@ -390,7 +390,7 @@ jobs:
         with:
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+          GITHUB_TOKEN: ${{{{ github.token }}}}
           NPM_TOKEN: ${{{{ secrets.NPM_TOKEN }}}}
 
   synthesize:
@@ -404,12 +404,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           healthcheck: 'true'
           release-tag: ${{{{ matrix.package.name }}}}@${{{{ matrix.package.version }}}}
-          github-token: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+          github-token: ${{{{ github.token }}}}
           llm-api-key: ${{{{ secrets.OPENROUTER_API_KEY }}}}
 {manifest_inputs}
 "#
@@ -444,7 +444,7 @@ jobs:
         with:
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+          GITHUB_TOKEN: ${{{{ github.token }}}}
           NPM_TOKEN: ${{{{ secrets.NPM_TOKEN }}}}
 
   synthesize:
@@ -455,12 +455,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           healthcheck: 'true'
           release-tag: v${{{{ fromJson(needs.{release_job}.outputs.published_packages)[0].version }}}}
-          github-token: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+          github-token: ${{{{ github.token }}}}
           llm-api-key: ${{{{ secrets.OPENROUTER_API_KEY }}}}
 {manifest_inputs}
 "#
@@ -489,12 +489,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           healthcheck: 'true'
           release-tag: ${{{{ github.event.release.tag_name }}}}
-          github-token: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+          github-token: ${{{{ github.token }}}}
           llm-api-key: ${{{{ secrets.OPENROUTER_API_KEY }}}}
 {manifest_inputs}
 "#

--- a/crates/landmark/src/setup_fleet/workflows.rs
+++ b/crates/landmark/src/setup_fleet/workflows.rs
@@ -101,17 +101,21 @@ pub(crate) fn release_please_synthesis_job(
         r#"synthesize:
   needs: {release_job}
   if: needs.{release_job}.outputs.release_created == 'true'
+  permissions:
+    contents: write
+    issues: write
+    pull-requests: write
   runs-on: ubuntu-latest
   steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: misty-step/landmark@v1
+    - uses: misty-step/landmark@v0
       with:
         mode: synthesis-only
         healthcheck: 'true'
         release-tag: ${{{{ needs.{release_job}.outputs.tag_name }}}}
-        github-token: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+        github-token: ${{{{ github.token }}}}
         llm-api-key: ${{{{ secrets.OPENROUTER_API_KEY }}}}
 {manifest_inputs}
 "#
@@ -129,6 +133,10 @@ pub(crate) fn changesets_synthesis_job(
             r#"synthesize:
   needs: {release_job}
   if: needs.{release_job}.outputs.published == 'true'
+  permissions:
+    contents: write
+    issues: write
+    pull-requests: write
   strategy:
     matrix:
       package: ${{{{ fromJson(needs.{release_job}.outputs.published_packages) }}}}
@@ -137,12 +145,12 @@ pub(crate) fn changesets_synthesis_job(
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: misty-step/landmark@v1
+    - uses: misty-step/landmark@v0
       with:
         mode: synthesis-only
         healthcheck: 'true'
         release-tag: ${{{{ matrix.package.name }}}}@${{{{ matrix.package.version }}}}
-        github-token: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+        github-token: ${{{{ github.token }}}}
         llm-api-key: ${{{{ secrets.OPENROUTER_API_KEY }}}}
 {manifest_inputs}
 "#
@@ -152,17 +160,21 @@ pub(crate) fn changesets_synthesis_job(
             r#"synthesize:
   needs: {release_job}
   if: needs.{release_job}.outputs.published == 'true'
+  permissions:
+    contents: write
+    issues: write
+    pull-requests: write
   runs-on: ubuntu-latest
   steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: misty-step/landmark@v1
+    - uses: misty-step/landmark@v0
       with:
         mode: synthesis-only
         healthcheck: 'true'
         release-tag: v${{{{ fromJson(needs.{release_job}.outputs.published_packages)[0].version }}}}
-        github-token: ${{{{ secrets.GH_RELEASE_TOKEN }}}}
+        github-token: ${{{{ github.token }}}}
         llm-api-key: ${{{{ secrets.OPENROUTER_API_KEY }}}}
 {manifest_inputs}
 "#

--- a/crates/landmark/src/tests.rs
+++ b/crates/landmark/src/tests.rs
@@ -197,7 +197,7 @@ fn setup_detects_semantic_release_and_reports_backfill_available() {
     let workflow = &setup_workflows(&diagnosis, None)["semantic-release"].content;
     assert!(workflow.contains("mode: full"));
     assert!(workflow.contains("healthcheck: 'true'"));
-    assert!(workflow.contains("GH_RELEASE_TOKEN"));
+    assert!(workflow.contains("github-token: ${{ github.token }}"));
 }
 
 #[test]
@@ -237,6 +237,11 @@ fn fleet_plan_patches_existing_release_please_workflow() {
     assert!(patch.content.contains("needs: release-please"));
     assert!(patch.content.contains("mode: synthesis-only"));
     assert!(patch.content.contains("healthcheck: 'true'"));
+    assert!(patch.content.contains("misty-step/landmark@v0"));
+    assert!(patch.content.contains("github-token: ${{ github.token }}"));
+    assert!(!patch.content.contains("GH_RELEASE_TOKEN"));
+    assert!(patch.content.contains("permissions:"));
+    assert!(patch.content.contains("pull-requests: write"));
 }
 
 #[test]
@@ -270,6 +275,12 @@ fn fleet_plan_patches_existing_changesets_workflow() {
     assert!(patch.content.contains("needs: release"));
     assert!(patch.content.contains("mode: synthesis-only"));
     assert!(patch.content.contains("healthcheck: 'true'"));
+    assert!(patch.content.contains("misty-step/landmark@v0"));
+    // The injected synthesize job uses the default token; the untouched
+    // pre-existing `release` job's own GH_RELEASE_TOKEN reference is left as-is.
+    assert!(patch.content.contains("github-token: ${{ github.token }}"));
+    assert!(patch.content.contains("permissions:"));
+    assert!(patch.content.contains("pull-requests: write"));
 }
 
 #[test]
@@ -467,7 +478,7 @@ fn org_secret_visibility_all_counts_for_fleet_secret_metadata() {
 
 #[test]
 fn fleet_detects_landmark_and_legacy_landmark_release_workflow_content() {
-    for action_ref in ["misty-step/landmark@v1", "misty-step/landmark@v1"] {
+    for action_ref in ["misty-step/landmark@v0", "misty-step/landmark@v0"] {
         let workflow_texts = vec![(
             "release.yml".to_string(),
             format!("steps:\n  - uses: {action_ref}\n"),
@@ -956,7 +967,7 @@ fn setup_generated_workflows_are_yaml() {
     assert!(manual.contains("release:\n    types: [published]"));
     assert!(!manual.contains("push:\n    tags:"));
     assert!(manual.contains("${{ github.event.release.tag_name }}"));
-    assert!(manual.contains("${{ secrets.GH_RELEASE_TOKEN }}"));
+    assert!(manual.contains("${{ github.token }}"));
 }
 
 #[test]

--- a/docs/fleet-integration-playbook.md
+++ b/docs/fleet-integration-playbook.md
@@ -67,14 +67,18 @@ mode. Keep the existing workflow path when patching an existing release
 workflow.
 
 ```yaml
-- uses: misty-step/landmark@v1
+- uses: misty-step/landmark@v0
   with:
     mode: synthesis-only
     healthcheck: "true"
     release-tag: ${{ steps.release.outputs.tag_name }}
-    github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+    github-token: ${{ github.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
+
+Add a job-level `permissions: { contents: write, issues: write, pull-requests:
+write }` block if the existing job doesn't already declare one — the default
+`github.token` only carries the permissions the job grants it.
 
 For manual GitHub Releases, add `.github/workflows/landmark-release.yml`:
 
@@ -98,13 +102,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           healthcheck: "true"
           node-version: "24"
           release-tag: ${{ github.event.release.tag_name }}
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           changelog-source: auto
 ```
@@ -149,11 +153,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Landmark
-        uses: misty-step/landmark@v1
+        uses: misty-step/landmark@v0
         with:
           mode: full
           healthcheck: "true"
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           node-version: "24"
           synthesis: "true"
@@ -164,8 +168,10 @@ jobs:
 
 GitHub workflows need:
 
-- `GH_RELEASE_TOKEN`: repository write access for releases and release-body
-  updates.
+- `github-token: ${{ github.token }}`: the default `GITHUB_TOKEN` covers
+  landmark's own action invocation as long as the job (or workflow) declares
+  the `permissions` block below. Only fall back to a PAT-backed secret when
+  downstream automation must trigger further workflow runs.
 - `OPENROUTER_API_KEY`: LLM synthesis. Missing or stale keys should not block
   release unless the repo deliberately sets `synthesis-required: "true"`.
 

--- a/examples/changesets-monorepo.yml
+++ b/examples/changesets-monorepo.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   synthesize:
@@ -44,11 +44,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           healthcheck: "true"
           release-tag: ${{ matrix.package.name }}@${{ matrix.package.version }}
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           changelog-source: release-body

--- a/examples/changesets.yml
+++ b/examples/changesets.yml
@@ -8,7 +8,7 @@
 #   4. Landmark synthesizes user-facing notes for the new release
 #
 # Requirements:
-#   - Repository secrets: GH_RELEASE_TOKEN, OPENROUTER_API_KEY
+#   - Repository secrets: OPENROUTER_API_KEY (github-token uses the default GITHUB_TOKEN)
 #   - Changesets initialized in repo (`npx changeset init`)
 #   - publish script that creates GitHub Releases (e.g., `changeset tag`)
 #
@@ -67,11 +67,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           release-tag: v${{ fromJson(needs.release.outputs.published_packages)[0].version }}
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional: customize synthesis behavior.
           # audience: developer

--- a/examples/healthcheck.yml
+++ b/examples/healthcheck.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           release-tag: v0.0.0
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           healthcheck: "true"
           synthesis: "false"

--- a/examples/manual-tag.yml
+++ b/examples/manual-tag.yml
@@ -9,7 +9,7 @@
 # including `gh release create`, the GitHub UI, or custom scripts.
 #
 # Requirements:
-#   - Repository secrets: GH_RELEASE_TOKEN, OPENROUTER_API_KEY
+#   - Repository secrets: OPENROUTER_API_KEY (github-token uses the default GITHUB_TOKEN)
 #   - A published GitHub Release (Landmark reads its body as input)
 #
 # Docs: https://github.com/misty-step/landmark
@@ -32,11 +32,11 @@ jobs:
 
       # Landmark synthesis-only mode skips semantic-release entirely and
       # synthesizes user-facing notes for the published release.
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           release-tag: ${{ github.event.release.tag_name }}
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Use the release body as source since there may be no CHANGELOG.md.
           changelog-source: auto

--- a/examples/release-please.yml
+++ b/examples/release-please.yml
@@ -7,7 +7,7 @@
 #   3. Landmark synthesizes user-facing notes and updates the release body
 #
 # Requirements:
-#   - Repository secrets: GH_RELEASE_TOKEN, OPENROUTER_API_KEY
+#   - Repository secrets: OPENROUTER_API_KEY (github-token uses the default GITHUB_TOKEN)
 #   - Conventional commits (https://www.conventionalcommits.org)
 #
 # Docs:
@@ -52,11 +52,11 @@ jobs:
 
       # Landmark synthesis-only mode: skips semantic-release entirely,
       # only runs LLM synthesis for the tag release-please just created.
-      - uses: misty-step/landmark@v1
+      - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           release-tag: ${{ needs.release-please.outputs.tag_name }}
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional: customize synthesis behavior.
           # audience: developer

--- a/examples/release.yml
+++ b/examples/release.yml
@@ -42,10 +42,10 @@ jobs:
       # Landmark: Automated semantic-release pipeline
       # https://github.com/misty-step/landmark
       - name: Run Landmark
-        uses: misty-step/landmark@v1
+        uses: misty-step/landmark@v0
         with:
-          # Personal access token with repository write access.
-          github-token: ${{ secrets.GH_RELEASE_TOKEN }}
+          # Default GITHUB_TOKEN; the job's `permissions` block above grants it write access.
+          github-token: ${{ github.token }}
           # OpenRouter API key for synthesized "What's New" notes.
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional: customize model and fallbacks.


### PR DESCRIPTION
## Summary
- Repoint every generator, template, and living doc from `misty-step/landmark@v1` to `@v0` so new adoptions land on the fleet's current pre-stable line instead of reintroducing `@v1`.
- Swap `github-token: ${{ secrets.GH_RELEASE_TOKEN }}` to `${{ github.token }}` in the workflow YAML the Rust generator emits (`setup_fleet/diagnose.rs`, `setup_fleet/workflows.rs`) and in the matching docs/examples, since the generated jobs already carry (or now carry) an explicit `contents`/`issues`/`pull-requests` `permissions` block and don't need a PAT.
- Added job-level `permissions:` blocks to the `synthesize` job templates that get patched into a repo's *existing* release-please/changesets workflow (`workflows.rs`), since those patches only add a job — they don't touch the host workflow's top-level `permissions`.
- Flipped the corresponding test expectations in `tests.rs` (kept every assertion, none deleted) and added a couple of regression assertions for the new `permissions:` block on the two fleet-patch tests.

## Scope notes (left alone, with reason)
- `crates/landmark/src/replay/fleet_scenarios.rs`, `setup_fleet/scan.rs`, `setup_fleet/plan.rs`, `setup_fleet/commands.rs`, `replay/contract_scenarios.rs`, `docs/agent-integration.md`, `docs/dogfood/*`: these own the **fleet required-secrets model** (`required_secrets = ["GH_RELEASE_TOKEN", "OPENROUTER_API_KEY"]`), which is a materially different, larger surface than "the generator that emits workflow YAML." Flipping that model to stop requiring `GH_RELEASE_TOKEN` fleet-wide is a separate, bigger decision (it changes what `fleet scan`/`fleet plan` report as required/missing secrets for every consumer repo) and wasn't in this lane's named scope. Left unchanged; flagging as a residual follow-up if the fleet secret model should also drop the PAT requirement.
- `README.md` lines using `--github-token "$GH_RELEASE_TOKEN"` (the `landmark backfill` CLI examples): left as-is — that's a local shell env var for CLI usage outside GitHub Actions, not a workflow secret; there's no `github.token` equivalent outside an Actions run.
- `README.md`/`AGENTS.md` prose describing `fleet plan`'s required-secret reporting (e.g. "does not require `GH_RELEASE_TOKEN`...") was left alone for the same reason as the fleet_scenarios.rs point above — it's accurately describing the (unchanged) fleet-scan subsystem.
- `README.md` and `SKILL.md` weren't in the lane's named file list but clearly "document the pin" per the ticket's stated goal, so I included them (8 + 1 occurrences) to avoid shipping visibly inconsistent docs.
- `backlog.d/_done/**` untouched per instruction (archival).

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --locked --all-targets -- -D warnings` — clean
- [x] `cargo test --locked` — 113/113 landmark tests + 5/5 landmark-mcp tests pass
- [x] `bin/check-architecture` — `architecture ratchet ok`

Powder: landmark-017

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow examples and guides to use the latest Landmark action reference and the built-in workflow token.
  * Clarified when a personal access token is still needed, and added guidance on required workflow permissions.

* **Bug Fixes**
  * Aligned generated release workflows with the new token-based setup across release, synthesis, healthcheck, and manual-tag examples.
  * Improved compatibility for release automation by removing the need for a dedicated release secret in standard cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->