### PR TITLE
ci(release): keep the self-release branch between cycles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,9 @@ jobs:
         with:
           token: ${{ steps.bot-token.outputs.token }}
           branch: ${{ steps.prepare.outputs.release_branch }}
-          delete-branch: true
+          # Keep the branch alive between cycles: the App token can update an
+          # existing branch but 403s creating one via git push (landmark-017).
+          delete-branch: false
           title: ${{ steps.prepare.outputs.pull_request_title }}
           commit-message: ${{ steps.prepare.outputs.commit_message }}
           body: |


### PR DESCRIPTION
The App token updates existing branches fine but 403s on branch creation via git push — verified live (pre-creating the ref made the identical push succeed, run 28987483978 rerun). `delete-branch: false` keeps the branch alive between release cycles so prepare-release-pr never has to create it. Part of Powder landmark-017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)