### PR TITLE
docs(adoption): replace GH_RELEASE_TOKEN PAT pattern with GitHub App tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,9 +135,14 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - uses: actions/create-github-app-token@v2
+        id: release-token
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
       - uses: misty-step/landmark@v0
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional:
           # llm-model: anthropic/claude-sonnet-4
@@ -147,10 +152,13 @@ jobs:
 ## Requirements
 - Node.js 22+
 - Rust stable
-- The workflow-level `permissions: { contents: write, issues: write, pull-requests: write }`
-  block above — the default `${{ github.token }}` covers landmark's own action
-  invocation; a PAT is only needed if downstream automation must trigger further
-  workflow runs.
+- A GitHub App installed on the repo with Contents: read/write, and its App
+  ID + private key as `LANDMARK_RELEASER_APP_ID` / `LANDMARK_RELEASER_PRIVATE_KEY`
+  secrets (see README's "Why a GitHub App, not a PAT"). The default
+  `${{ github.token }}` covers landmark's own action invocation but its tags
+  and releases do not trigger further workflow runs the way an App
+  installation token does — use the App when downstream automation depends
+  on that trigger.
 - `OPENROUTER_API_KEY` secret (or another compatible provider API key)
 
 ## Backlog And Docs

--- a/README.md
+++ b/README.md
@@ -119,12 +119,22 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Short-lived installation token from a GitHub App installed on this
+      # repo, in place of a personal access token. See "Why a GitHub App,
+      # not a PAT" below.
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
+
       # Landmark: Automated semantic-release pipeline
       # https://github.com/misty-step/landmark
       - name: Run Landmark
         uses: misty-step/landmark@v0
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional: customize model and fallbacks
           # llm-model: anthropic/claude-sonnet-5
@@ -134,6 +144,33 @@ jobs:
 Landmark is language-agnostic. Your repo does not need `package.json` or Node.js
 unless full mode is running `semantic-release`; the action handles its own Node
 24 runtime setup.
+
+#### Why a GitHub App, not a PAT
+
+`github-token` accepts any token with repo write access, but a personal access
+token ties the release pipeline to one person's account, expires or gets
+revoked out of band, and carries whatever scope that account has everywhere
+else. Prefer a GitHub App:
+
+- **Short-lived**: `actions/create-github-app-token` mints a token that lives
+  for one run, not months.
+- **Scoped to exactly what Landmark needs**: install the App only on the
+  repos it releases, with Contents (read/write) and nothing else unless a
+  plugin requires it.
+- **Tags still trigger downstream workflows.** This is the part
+  `secrets.GITHUB_TOKEN` (the ambient per-run token GitHub Actions already
+  gives every job, no setup required) cannot do: tags and releases it
+  creates do not fire `push: tags` or `release: published` on other
+  workflows in the same repo. An installation token from an App does. If
+  your pipeline has nothing downstream of the release tag, `GITHUB_TOKEN`
+  is simpler and requires no secrets at all — reach for the App only when
+  you need that trigger.
+
+Create the App once per organization (Settings → Developer settings →
+GitHub Apps; Contents: Read & write, Metadata: Read-only), install it on
+your release repos, and store its App ID and private key as
+`LANDMARK_RELEASER_APP_ID` / `LANDMARK_RELEASER_PRIVATE_KEY` (or repo-local
+equivalents) — every example in this README uses those names.
 
 Full mode's version/changelog/tag/release decisions are `semantic-release`'s,
 kept only as a named **compatibility path** for repos that already run it.
@@ -196,14 +233,16 @@ stable SemVer automatically. No config change is required.
 ### GitHub Action Synthesis-Only Mode
 
 Use synthesis-only when release-please, Changesets, manual GitHub Releases, or a
-custom pipeline already creates the version and release:
+custom pipeline already creates the version and release. Mint a token first
+(see [Why a GitHub App, not a PAT](#why-a-github-app-not-a-pat)), then run
+Landmark after your release-creating step:
 
 ```yaml
 - uses: misty-step/landmark@v0
   with:
     mode: synthesis-only
     release-tag: ${{ steps.release.outputs.tag_name }}
-    github-token: ${{ github.token }}
+    github-token: ${{ steps.release-token.outputs.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
 
@@ -293,7 +332,7 @@ checked-in `.landmark.yml`. It prints a JSON report with a recommended Landmark
 mode and writes workflow candidates for semantic-release, release-please,
 changesets, changesets monorepos, and manual-tag repositories. Every generated
 workflow includes `healthcheck: 'true'`, the default `GITHUB_TOKEN` (via
-`github-token: ${{ github.token }}`), `OPENROUTER_API_KEY`, and the
+`github-token: ${{ steps.release-token.outputs.token }}`), `OPENROUTER_API_KEY`, and the
 `contents`, `issues`, and `pull-requests` permissions Landmark needs.
 
 ## Fleet Adoption
@@ -480,7 +519,7 @@ release-mutating workflow.
 | --- | --- | --- | --- |
 | `mode` | No | `full` | Pipeline mode: `full` (semantic-release + synthesis) or `synthesis-only` (synthesize for existing tag). |
 | `release-tag` | No* | `""` | Release tag to synthesize notes for (required when `mode: synthesis-only`). |
-| `github-token` | Yes | - | Personal access token with repo write access. Used by `semantic-release` and GitHub API update calls. |
+| `github-token` | Yes | - | GitHub App installation token or PAT with repo write access. Used by `semantic-release` and GitHub API update calls. See [Why a GitHub App, not a PAT](#why-a-github-app-not-a-pat). |
 | `llm-api-key` | No* | - | API key for synthesis (OpenRouter, OpenAI, or compatible providers). |
 | `llm-model` | No | manifest policy default | Primary model ID for note synthesis. |
 | `llm-fallback-models` | No | manifest, then `google/gemini-2.5-flash,anthropic/claude-haiku-4.5` | Comma-separated fallback model IDs tried in order if primary fails. |
@@ -573,7 +612,7 @@ distribution steps:
 ```yaml
 - uses: misty-step/landmark@v0
   with:
-    github-token: ${{ github.token }}
+    github-token: ${{ steps.release-token.outputs.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
 
@@ -582,7 +621,7 @@ distribution steps:
 ```yaml
 - uses: misty-step/landmark@v0
   with:
-    github-token: ${{ github.token }}
+    github-token: ${{ steps.release-token.outputs.token }}
     llm-api-key: ${{ secrets.OPENAI_API_KEY }}
     llm-model: gpt-4o
     llm-api-url: https://api.openai.com/v1/chat/completions
@@ -593,7 +632,7 @@ distribution steps:
 ```yaml
 - uses: misty-step/landmark@v0
   with:
-    github-token: ${{ github.token }}
+    github-token: ${{ steps.release-token.outputs.token }}
     llm-api-key: ${{ secrets.PROVIDER_API_KEY }}
     llm-model: provider/model-id
     llm-api-url: https://provider.example.com/v1/chat/completions
@@ -617,7 +656,7 @@ landmark backfill \
   --since v1.0.0 \
   --mode artifacts-only \
   --repository owner/repo \
-  --github-token "$GH_RELEASE_TOKEN"
+  --github-token "$GITHUB_TOKEN"
 ```
 
 Preview GitHub Release body updates before considering mutation:
@@ -629,7 +668,7 @@ landmark backfill \
   --mode release-body \
   --dry-run \
   --repository owner/repo \
-  --github-token "$GH_RELEASE_TOKEN"
+  --github-token "$GITHUB_TOKEN"
 ```
 
 `release-body` writes are refused unless the run is a dry-run or the operator passes `--confirm-release-body`. The output manifest lists processed tags, skipped tags, remaining tags, artifact paths, preview hashes, and the estimated cost. Artifact backfill does not call the LLM; use the manifest to batch later synthesis if you want enhanced historical notes.
@@ -643,7 +682,7 @@ For private repos where GitHub Releases aren't publicly visible, use artifact ou
   id: landmark
   uses: misty-step/landmark@v0
   with:
-    github-token: ${{ github.token }}
+    github-token: ${{ steps.release-token.outputs.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
     notes-output-file: docs/releases/{version}.md
     notes-output-text-file: docs/releases/{version}.txt
@@ -782,7 +821,7 @@ To publish a simple RSS 2.0 release feed (for feed readers, docs sites, etc.), s
 ```yaml
 - uses: misty-step/landmark@v0
   with:
-    github-token: ${{ github.token }}
+    github-token: ${{ steps.release-token.outputs.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
     rss-feed-file: docs/releases.xml
     rss-max-entries: "50"

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -52,7 +52,7 @@ landmark run \
   --repo-root . \
   --repository owner/repo \
   --release-tag v1.2.3 \
-  --github-token "$GH_RELEASE_TOKEN" \
+  --github-token "$GITHUB_TOKEN" \
   --publish-release-body
 ```
 

--- a/docs/fleet-integration-playbook.md
+++ b/docs/fleet-integration-playbook.md
@@ -67,18 +67,19 @@ mode. Keep the existing workflow path when patching an existing release
 workflow.
 
 ```yaml
+- uses: actions/create-github-app-token@v2
+  id: release-token
+  with:
+    app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+    private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
 - uses: misty-step/landmark@v0
   with:
     mode: synthesis-only
     healthcheck: "true"
     release-tag: ${{ steps.release.outputs.tag_name }}
-    github-token: ${{ github.token }}
+    github-token: ${{ steps.release-token.outputs.token }}
     llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
-
-Add a job-level `permissions: { contents: write, issues: write, pull-requests:
-write }` block if the existing job doesn't already declare one — the default
-`github.token` only carries the permissions the job grants it.
 
 For manual GitHub Releases, add `.github/workflows/landmark-release.yml`:
 
@@ -102,13 +103,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: actions/create-github-app-token@v2
+        id: release-token
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
       - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           healthcheck: "true"
           node-version: "24"
           release-tag: ${{ github.event.release.tag_name }}
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           changelog-source: auto
 ```
@@ -152,12 +158,18 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
       - name: Run Landmark
         uses: misty-step/landmark@v0
         with:
           mode: full
           healthcheck: "true"
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           node-version: "24"
           synthesis: "true"
@@ -168,10 +180,14 @@ jobs:
 
 GitHub workflows need:
 
-- `github-token: ${{ github.token }}`: the default `GITHUB_TOKEN` covers
-  landmark's own action invocation as long as the job (or workflow) declares
-  the `permissions` block below. Only fall back to a PAT-backed secret when
-  downstream automation must trigger further workflow runs.
+- A GitHub App installed on the repo with Contents: read/write (Metadata:
+  read-only), and its App ID + private key stored as
+  `LANDMARK_RELEASER_APP_ID` / `LANDMARK_RELEASER_PRIVATE_KEY`. Mint a
+  short-lived installation token per run via `actions/create-github-app-token`
+  rather than a personal access token or the ambient `github.token` — App
+  tokens still trigger downstream workflows on the tags/releases they create,
+  which `github.token` cannot do (see README's "Why a GitHub App, not a
+  PAT").
 - `OPENROUTER_API_KEY`: LLM synthesis. Missing or stale keys should not block
   release unless the repo deliberately sets `synthesis-required: "true"`.
 

--- a/examples/changesets-monorepo.yml
+++ b/examples/changesets-monorepo.yml
@@ -26,12 +26,19 @@ jobs:
 
       - run: npm ci
 
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
+
       - uses: changesets/action@v1
         id: changesets
         with:
           publish: npm run release
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ steps.release-token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   synthesize:
@@ -44,11 +51,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
+
       - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           healthcheck: "true"
           release-tag: ${{ matrix.package.name }}@${{ matrix.package.version }}
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           changelog-source: release-body

--- a/examples/changesets.yml
+++ b/examples/changesets.yml
@@ -8,7 +8,8 @@
 #   4. Landmark synthesizes user-facing notes for the new release
 #
 # Requirements:
-#   - Repository secrets: OPENROUTER_API_KEY (github-token uses the default GITHUB_TOKEN)
+#   - Repository secrets: LANDMARK_RELEASER_APP_ID, LANDMARK_RELEASER_PRIVATE_KEY,
+#     OPENROUTER_API_KEY (see landmark's README, "Why a GitHub App, not a PAT")
 #   - Changesets initialized in repo (`npx changeset init`)
 #   - publish script that creates GitHub Releases (e.g., `changeset tag`)
 #
@@ -67,11 +68,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
+
       - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           release-tag: v${{ fromJson(needs.release.outputs.published_packages)[0].version }}
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional: customize synthesis behavior.
           # audience: developer

--- a/examples/healthcheck.yml
+++ b/examples/healthcheck.yml
@@ -17,11 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
+
       - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           release-tag: v0.0.0
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           healthcheck: "true"
           synthesis: "false"

--- a/examples/manual-tag.yml
+++ b/examples/manual-tag.yml
@@ -9,7 +9,8 @@
 # including `gh release create`, the GitHub UI, or custom scripts.
 #
 # Requirements:
-#   - Repository secrets: OPENROUTER_API_KEY (github-token uses the default GITHUB_TOKEN)
+#   - Repository secrets: LANDMARK_RELEASER_APP_ID, LANDMARK_RELEASER_PRIVATE_KEY,
+#     OPENROUTER_API_KEY (see landmark's README, "Why a GitHub App, not a PAT")
 #   - A published GitHub Release (Landmark reads its body as input)
 #
 # Docs: https://github.com/misty-step/landmark
@@ -30,13 +31,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
+
       # Landmark synthesis-only mode skips semantic-release entirely and
       # synthesizes user-facing notes for the published release.
       - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           release-tag: ${{ github.event.release.tag_name }}
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Use the release body as source since there may be no CHANGELOG.md.
           changelog-source: auto

--- a/examples/release-please.yml
+++ b/examples/release-please.yml
@@ -7,7 +7,8 @@
 #   3. Landmark synthesizes user-facing notes and updates the release body
 #
 # Requirements:
-#   - Repository secrets: OPENROUTER_API_KEY (github-token uses the default GITHUB_TOKEN)
+#   - Repository secrets: LANDMARK_RELEASER_APP_ID, LANDMARK_RELEASER_PRIVATE_KEY,
+#     OPENROUTER_API_KEY (see landmark's README, "Why a GitHub App, not a PAT")
 #   - Conventional commits (https://www.conventionalcommits.org)
 #
 # Docs:
@@ -50,13 +51,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
+
       # Landmark synthesis-only mode: skips semantic-release entirely,
       # only runs LLM synthesis for the tag release-please just created.
       - uses: misty-step/landmark@v0
         with:
           mode: synthesis-only
           release-tag: ${{ needs.release-please.outputs.tag_name }}
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional: customize synthesis behavior.
           # audience: developer

--- a/examples/release.yml
+++ b/examples/release.yml
@@ -39,13 +39,22 @@ jobs:
           # Landmark sets an authenticated remote URL during release.
           persist-credentials: false
 
+      # Short-lived installation token from a GitHub App installed on this
+      # repo, instead of a personal access token. See README's "Why a
+      # GitHub App, not a PAT".
+      - name: Mint release token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LANDMARK_RELEASER_APP_ID }}
+          private-key: ${{ secrets.LANDMARK_RELEASER_PRIVATE_KEY }}
+
       # Landmark: Automated semantic-release pipeline
       # https://github.com/misty-step/landmark
       - name: Run Landmark
         uses: misty-step/landmark@v0
         with:
-          # Default GITHUB_TOKEN; the job's `permissions` block above grants it write access.
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.release-token.outputs.token }}
           # OpenRouter API key for synthesized "What's New" notes.
           llm-api-key: ${{ secrets.OPENROUTER_API_KEY }}
           # Optional: customize model and fallbacks.


### PR DESCRIPTION
## Summary
- The org's shared `GH_RELEASE_TOKEN` bot PAT is decommissioned (misty-step-940). #207 landed a `github.token` stopgap ahead of that ruling. Every consumer-facing adoption example — README.md, AGENTS.md, `docs/fleet-integration-playbook.md`, `docs/agent-integration.md`, and all `examples/*.yml` — now mints a short-lived installation token via `actions/create-github-app-token` and feeds it to landmark's `github-token` input, superseding the `github.token` stopgap: unlike `GITHUB_TOKEN`, App tokens still trigger downstream workflows on the tags/releases they create.
- Adds a "Why a GitHub App, not a PAT" section to the README. Updates the `github-token` input description accordingly.
- Rebased onto #207's `landmark@v0` re-pin (pre-stable version-line reset, unrelated to this change) rather than reverting it.
- Renames the local-CLI `$GH_RELEASE_TOKEN` shell placeholder to `$GITHUB_TOKEN` in the manual `landmark backfill`/`landmark run` bash examples (not a workflow secret, just a clearer name).

## Deliberately not touched
- `crates/**/*.rs`: the fleet-plan/fleet-scan generators (`setup_fleet/{commands,plan,scan}.rs`) still literally require `GH_RELEASE_TOKEN` as a secret name (README.md:400 describes that real behavior accurately) — the single-repo `setup` generator was already updated in #207 to emit `github.token`, so the two generator paths are now inconsistent with each other and with this PR's App pattern. Follow-up needed in the generators themselves, out of this doc-only ticket's scope.
- `docs/dogfood/2026-06-13-fleet-adoption.md`: a dated historical session log, not living documentation.

## Test plan
- [x] `cargo run --locked -p landmark -- check-action-contract --repo-root .` → `action contract ok` (validates README input coverage, docs link targets, and `examples/manual-tag.yml` structure)
- [x] `actionlint examples/*.yml` clean
- [x] YAML-validated every touched `examples/*.yml`

Agent-Task: misty-step-940